### PR TITLE
chore(repo): add GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,0 +1,27 @@
+---
+name: Bug
+about: Something is broken or behaves unexpectedly
+title: "fix(<area>): <short summary>"
+labels: ["type:bug"]
+---
+
+<!--
+Replace <area> in the title with one of:
+api, admin-desktop, waiter-web, shared-types, api-client, auth-context, e2e.
+
+Add the relevant area:* and priority:* labels after opening.
+-->
+
+## Steps to reproduce
+1. 
+2. 
+3. 
+
+## Expected
+- 
+
+## Actual
+- 
+
+## Acceptance criteria
+- 

--- a/.github/ISSUE_TEMPLATE/chore.md
+++ b/.github/ISSUE_TEMPLATE/chore.md
@@ -1,0 +1,23 @@
+---
+name: Chore
+about: Tooling, scaffolding, refactor, or non-feature maintenance
+title: "chore(<area>): <short summary>"
+labels: ["type:chore"]
+---
+
+<!--
+One- or two-sentence summary describing the change and its motivation.
+Replace <area> in the title with one of:
+api, admin-desktop, waiter-web, shared-types, api-client, auth-context, e2e.
+
+Add the relevant area:* and priority:* labels after opening.
+-->
+
+## Scope
+- 
+- 
+- 
+
+## Acceptance criteria
+- 
+- 

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -1,0 +1,23 @@
+---
+name: Feature
+about: A new feature in one of the apps or packages
+title: "feat(<area>): <short summary>"
+labels: ["type:feature"]
+---
+
+<!--
+One- or two-sentence summary describing what the feature does and which API
+endpoints / packages it touches. Replace <area> in the title with one of:
+api, admin-desktop, waiter-web, shared-types, api-client, auth-context, e2e.
+
+Add the relevant area:* and priority:* labels after opening.
+-->
+
+## Scope
+- 
+- 
+- 
+
+## Acceptance criteria
+- 
+- 


### PR DESCRIPTION
Adds `.github/ISSUE_TEMPLATE/` so new issues auto-populate the same shape we've been using (Scope / Acceptance criteria, conventional-commit title, type label preset).