### PR TITLE
Serva-91 feat(api,waiter-web): print order bons after submit

### DIFF
--- a/apps/admin-desktop/src/App.css
+++ b/apps/admin-desktop/src/App.css
@@ -491,6 +491,37 @@ html, body, #root {
   margin-bottom: 4px;
 }
 
+.login-card .back-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  background: none;
+  border: none;
+  color: var(--color-muted);
+  font-size: 13px;
+  font-weight: 500;
+  padding: 4px 8px 4px 0;
+  margin-bottom: 16px;
+  cursor: pointer;
+  border-radius: var(--radius);
+  transition: color 0.12s, background 0.12s;
+}
+
+.login-card .back-button:hover:not(:disabled) {
+  color: var(--color-text);
+  background: var(--color-bg);
+}
+
+.login-card .back-button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.login-card .back-button__icon {
+  font-size: 18px;
+  line-height: 1;
+}
+
 .login-subtitle {
   color: var(--color-muted);
   font-size: 13px;

--- a/apps/admin-desktop/src/pages/AdminLoginPage.tsx
+++ b/apps/admin-desktop/src/pages/AdminLoginPage.tsx
@@ -39,6 +39,16 @@ export function AdminLoginPage() {
       </div>
       <div className="login-page">
         <div className="login-card">
+          <button
+            type="button"
+            className="back-button"
+            onClick={() => navigate("/events")}
+            disabled={isLoggingIn}
+            aria-label="Zurueck zur Veranstaltungsliste"
+          >
+            <span className="back-button__icon" aria-hidden="true">&#8249;</span>
+            <span>Veranstaltungen</span>
+          </button>
           <h1>Serva</h1>
           <p className="login-subtitle">Admin-Anmeldung &middot; Veranstaltung #{paramEventId}</p>
           <form onSubmit={handleSubmit}>

--- a/apps/api/src/domain/printer-store.ts
+++ b/apps/api/src/domain/printer-store.ts
@@ -1,5 +1,7 @@
 ﻿import Database from "better-sqlite3";
 import type {
+  OrderPrintResponse,
+  OrderPrintResultDto,
   PrinterCreateRequest,
   PrinterDto,
   PrinterTestPrintResponse,
@@ -15,6 +17,33 @@ type PrinterRow = {
   ipAddress: string;
   connectionDetails: string;
 };
+
+type OrderRowForPrint = {
+  id: number;
+  timestamp: string;
+  tableName: string;
+  waiterUsername: string;
+};
+
+type OrderItemRowForPrint = {
+  menuItemName: string;
+  quantity: number;
+  specialRequests: string;
+  printerId: number | null;
+  printerName: string | null;
+  printerIpAddress: string | null;
+  printerConnectionDetails: string | null;
+};
+
+// Renders an ISO timestamp as HH:MM in the host's local time. The kitchen only
+// cares about wall-clock when the bon was placed, not the date.
+function formatTimeOnly(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return iso;
+  const hh = String(d.getHours()).padStart(2, "0");
+  const mm = String(d.getMinutes()).padStart(2, "0");
+  return `${hh}:${mm}`;
+}
 
 export class PrinterStore {
   constructor(private readonly eventStore: EventStore) {}
@@ -296,6 +325,231 @@ export class PrinterStore {
     } finally {
       db.close();
     }
+  }
+
+  async printOrder(orderId: number): Promise<OrderPrintResponse> {
+    const db = this.openActiveEventDb();
+    try {
+      this.ensureOrderPrintReadSchema(db);
+
+      const order = db
+        .prepare(
+          `
+          SELECT
+            o.id as id,
+            o.timestamp as timestamp,
+            COALESCE(t.name, '') as tableName,
+            COALESCE(u.username, '') as waiterUsername
+          FROM Orders o
+          LEFT JOIN Tables t ON t.id = o.table_id
+          LEFT JOIN Users u ON u.id = o.user_id
+          WHERE o.id = ?
+          `
+        )
+        .get(orderId) as OrderRowForPrint | undefined;
+
+      if (!order) {
+        throw new ApiError(404, "ORDER_NOT_FOUND", "Order not found");
+      }
+
+      const items = db
+        .prepare(
+          `
+          SELECT
+            mi.name as menuItemName,
+            oi.quantity as quantity,
+            COALESCE(oi.specialRequests, '') as specialRequests,
+            mc.printer_id as printerId,
+            p.name as printerName,
+            p.ipAddress as printerIpAddress,
+            p.connectionDetails as printerConnectionDetails
+          FROM OrderItems oi
+          JOIN MenuItems mi ON mi.id = oi.menuItem_id
+          JOIN MenuCategories mc ON mc.id = mi.menuCategory_id
+          LEFT JOIN Printers p ON p.id = mc.printer_id
+          WHERE oi.order_id = ?
+          ORDER BY mc.weight ASC, mi.weight ASC, mi.name COLLATE NOCASE ASC
+          `
+        )
+        .all(orderId) as OrderItemRowForPrint[];
+
+      type Group = {
+        printerId: number | null;
+        printerName: string;
+        printerIpAddress: string | null;
+        printerConnectionDetails: string | null;
+        items: OrderItemRowForPrint[];
+      };
+
+      const groups = new Map<string, Group>();
+      for (const item of items) {
+        const key = item.printerId === null ? "none" : String(item.printerId);
+        const existing = groups.get(key);
+        if (existing) {
+          existing.items.push(item);
+          continue;
+        }
+        groups.set(key, {
+          printerId: item.printerId,
+          printerName: item.printerName ?? "(kein Drucker zugewiesen)",
+          printerIpAddress: item.printerIpAddress,
+          printerConnectionDetails: item.printerConnectionDetails,
+          items: [item],
+        });
+      }
+
+      const results: OrderPrintResultDto[] = [];
+      for (const group of groups.values()) {
+        const itemCount = group.items.reduce((sum, it) => sum + it.quantity, 0);
+
+        if (group.printerId === null || group.printerIpAddress === null) {
+          results.push({
+            printerName: group.printerName,
+            status: "skipped",
+            itemCount,
+            message:
+              "Diese Artikel haben keinen Drucker zugewiesen und wurden nicht gedruckt.",
+            code: "NO_PRINTER_ASSIGNED",
+          });
+          continue;
+        }
+
+        const port = this.getPort(group.printerConnectionDetails ?? "");
+        const target = `${group.printerIpAddress}:${port}`;
+        const printer = this.createThermalPrinter(target);
+
+        try {
+          const connected = await printer.isPrinterConnected();
+          if (!connected) {
+            throw new ApiError(
+              409,
+              "PRINTER_CONNECTION_FAILED",
+              `No response from printer '${group.printerName}' at ${target}.`,
+              {
+                target,
+                hint: "Check IP/port configuration and printer power/network state.",
+              }
+            );
+          }
+
+          this.formatOrderBon(printer, {
+            printerName: group.printerName,
+            order,
+            items: group.items,
+          });
+
+          await printer.execute();
+
+          results.push({
+            printerId: group.printerId,
+            printerName: group.printerName,
+            status: "ok",
+            itemCount,
+            message: `Bon an '${group.printerName}' gedruckt.`,
+            target,
+          });
+        } catch (error) {
+          const apiError =
+            error instanceof ApiError
+              ? error
+              : this.mapPrinterConnectionError({
+                  error,
+                  printerName: group.printerName,
+                  target,
+                });
+
+          const details = apiError.details as
+            | { target?: string; hint?: string }
+            | undefined;
+
+          results.push({
+            printerId: group.printerId,
+            printerName: group.printerName,
+            status: "error",
+            itemCount,
+            message: apiError.message,
+            code: apiError.code,
+            target: details?.target ?? target,
+            hint: details?.hint,
+          });
+        }
+      }
+
+      return {
+        orderId: order.id,
+        printingEnabled: true,
+        results,
+      };
+    } finally {
+      db.close();
+    }
+  }
+
+  private ensureOrderPrintReadSchema(db: Database.Database) {
+    // Defensive: the order/menu/table tables are normally created by their own
+    // stores before printing happens, but in tests we may print right after
+    // submitting and expect the joins to resolve cleanly.
+    db.exec(`
+      CREATE TABLE IF NOT EXISTS Orders (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        timestamp TEXT NOT NULL,
+        table_id INTEGER NOT NULL,
+        user_id INTEGER NOT NULL
+      );
+      CREATE TABLE IF NOT EXISTS OrderItems (
+        order_id INTEGER NOT NULL,
+        menuItem_id INTEGER NOT NULL,
+        quantity INTEGER NOT NULL,
+        specialRequests TEXT NOT NULL DEFAULT '',
+        PRIMARY KEY (order_id, menuItem_id)
+      );
+    `);
+  }
+
+  private formatOrderBon(
+    printer: ThermalPrinter,
+    input: {
+      printerName: string;
+      order: OrderRowForPrint;
+      items: OrderItemRowForPrint[];
+    }
+  ) {
+    const { printerName, order, items } = input;
+    const orderedAt = formatTimeOnly(order.timestamp);
+
+    // Table name dominates the header — it's what kitchen staff scan for at a
+    // glance. setTextSize(2,2) is large but leaves the line on a single row.
+    printer.alignCenter();
+    printer.setTextSize(2, 2);
+    printer.println(`${order.tableName || "?"}`);
+    printer.setTextNormal();
+    printer.newLine();
+    printer.println(printerName);
+    printer.drawLine();
+
+    printer.alignLeft();
+    printer.println(`Bestellung #${order.id}`);
+    printer.println(`Kellner: ${order.waiterUsername || "?"}`);
+    printer.println(`Zeit: ${orderedAt}`);
+    printer.drawLine();
+
+    for (const item of items) {
+      // Items with a special request collapse to a single line that leads with
+      // `*` and shows the request text in place of the menu item name. The
+      // kitchen scans the asterisk to spot modified items at a glance.
+      const line = item.specialRequests
+        ? `*${item.quantity}x ${item.specialRequests}`
+        : `${item.quantity}x ${item.menuItemName}`;
+      printer.setTextQuadArea();
+      printer.println(line);
+      printer.setTextNormal();
+    }
+
+    printer.drawLine();
+    printer.alignCenter();
+    printer.println("Ende Bon");
+    printer.newLine();
+    printer.cut();
   }
 
   async sendTestPrint(printerId: number): Promise<PrinterTestPrintResponse> {

--- a/apps/api/src/routes/orders.print.test.ts
+++ b/apps/api/src/routes/orders.print.test.ts
@@ -1,0 +1,368 @@
+import assert from "node:assert/strict";
+import net from "node:net";
+import test from "node:test";
+import Database from "better-sqlite3";
+import { buildApp } from "../app";
+import { eventStore } from "../domain/state";
+import { setupEventTestUtils } from "../test-utils/event-test-utils";
+
+const {
+  createEventPrefix,
+  createActiveDbFixture,
+  createAppFixture,
+  createAuthFixture,
+} = setupEventTestUtils(test, eventStore);
+
+// Tiny TCP echo to stand in for a thermal printer. Captures the byte count so
+// tests can assert that something was actually sent.
+async function startFakePrinter() {
+  let receivedBytes = 0;
+  let connections = 0;
+  const server = net.createServer((socket) => {
+    connections += 1;
+    socket.on("data", (chunk) => {
+      receivedBytes += chunk.length;
+    });
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      server.off("error", reject);
+      resolve();
+    });
+  });
+
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("Failed to acquire fake printer address");
+  }
+
+  return {
+    port: address.port,
+    getConnections: () => connections,
+    getReceivedBytes: () => receivedBytes,
+    close: async () =>
+      new Promise<void>((resolve, reject) => {
+        server.close((err) => (err ? reject(err) : resolve()));
+      }),
+  };
+}
+
+function seedSchemaAndData(
+  dbFilePath: string,
+  options: { printerPort?: number; assignPrinter: boolean },
+) {
+  const db = new Database(dbFilePath);
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS Tables (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      name TEXT NOT NULL,
+      weight INTEGER NOT NULL DEFAULT 0,
+      isLocked INTEGER NOT NULL DEFAULT 0
+    );
+    CREATE TABLE IF NOT EXISTS Printers (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      name TEXT NOT NULL,
+      ipAddress TEXT NOT NULL,
+      connectionDetails TEXT NOT NULL DEFAULT ''
+    );
+    CREATE TABLE IF NOT EXISTS MenuCategories (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      name TEXT NOT NULL,
+      description TEXT NOT NULL DEFAULT '',
+      isLocked INTEGER NOT NULL DEFAULT 0,
+      weight INTEGER NOT NULL DEFAULT 0,
+      printer_id INTEGER,
+      orderDisplay_id INTEGER
+    );
+    CREATE TABLE IF NOT EXISTS MenuItems (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      name TEXT NOT NULL,
+      description TEXT NOT NULL DEFAULT '',
+      weight INTEGER NOT NULL DEFAULT 0,
+      price REAL NOT NULL DEFAULT 0,
+      isLocked INTEGER NOT NULL DEFAULT 0,
+      menuCategory_id INTEGER NOT NULL
+    );
+  `);
+
+  const tableId = Number(
+    db
+      .prepare("INSERT INTO Tables (name, weight, isLocked) VALUES (?, ?, ?)")
+      .run("T1", 0, 0).lastInsertRowid,
+  );
+
+  let printerId: number | null = null;
+  if (options.assignPrinter && options.printerPort !== undefined) {
+    printerId = Number(
+      db
+        .prepare(
+          "INSERT INTO Printers (name, ipAddress, connectionDetails) VALUES (?, ?, ?)",
+        )
+        .run("Kitchen", "127.0.0.1", String(options.printerPort)).lastInsertRowid,
+    );
+  }
+
+  const categoryId = Number(
+    db
+      .prepare(
+        "INSERT INTO MenuCategories (name, description, isLocked, weight, printer_id, orderDisplay_id) VALUES (?, ?, ?, ?, ?, NULL)",
+      )
+      .run("Food", "", 0, 0, printerId).lastInsertRowid,
+  );
+
+  const menuItemId = Number(
+    db
+      .prepare(
+        "INSERT INTO MenuItems (name, description, weight, price, isLocked, menuCategory_id) VALUES (?, ?, ?, ?, ?, ?)",
+      )
+      .run("Burger", "", 0, 7.5, 0, categoryId).lastInsertRowid,
+  );
+
+  db.close();
+  return { tableId, menuItemId, printerId };
+}
+
+test(
+  "POST /orders/:orderId/print prints to assigned printer",
+  { concurrency: false },
+  async () => {
+    const fakePrinter = await startFakePrinter();
+    try {
+      const eventPasscode = "print-ok-pass";
+      const created = createActiveDbFixture({
+        eventName: createEventPrefix("orders-print-ok"),
+        eventPasscode,
+        adminUsername: "chef",
+        adminPassword: "secret123",
+      }).event;
+      const { tableId, menuItemId } = seedSchemaAndData(created.dbFilePath, {
+        printerPort: fakePrinter.port,
+        assignPrinter: true,
+      });
+
+      const app = await createAppFixture(buildApp);
+      const auth = createAuthFixture(app);
+      const waiter = await auth.loginWaiter({
+        username: "print-waiter",
+        eventPasscode,
+      });
+
+      const create = await app.inject({
+        method: "POST",
+        url: "/orders",
+        headers: { authorization: `Bearer ${waiter.accessToken}` },
+        payload: {
+          tableId,
+          items: [{ menuItemId, quantity: 2, specialRequests: "no onions" }],
+        },
+      });
+      assert.equal(create.statusCode, 201);
+      const orderId = (create.json() as { id: number }).id;
+
+      const print = await app.inject({
+        method: "POST",
+        url: `/orders/${orderId}/print`,
+        headers: { authorization: `Bearer ${waiter.accessToken}` },
+      });
+
+      assert.equal(print.statusCode, 200);
+      const body = print.json() as {
+        orderId: number;
+        printingEnabled: boolean;
+        results: Array<{ status: string; printerName: string; itemCount: number }>;
+      };
+      assert.equal(body.orderId, orderId);
+      assert.equal(body.printingEnabled, true);
+      assert.equal(body.results.length, 1);
+      assert.equal(body.results[0].status, "ok");
+      assert.equal(body.results[0].printerName, "Kitchen");
+      assert.equal(body.results[0].itemCount, 2);
+      assert.ok(fakePrinter.getConnections() > 0);
+    } finally {
+      await fakePrinter.close();
+    }
+  },
+);
+
+test(
+  "POST /orders/:orderId/print returns skipped when no printer assigned",
+  { concurrency: false },
+  async () => {
+    const eventPasscode = "print-skip-pass";
+    const created = createActiveDbFixture({
+      eventName: createEventPrefix("orders-print-skip"),
+      eventPasscode,
+      adminUsername: "chef",
+      adminPassword: "secret123",
+    }).event;
+    const { tableId, menuItemId } = seedSchemaAndData(created.dbFilePath, {
+      assignPrinter: false,
+    });
+
+    const app = await createAppFixture(buildApp);
+    const auth = createAuthFixture(app);
+    const waiter = await auth.loginWaiter({
+      username: "skip-waiter",
+      eventPasscode,
+    });
+
+    const create = await app.inject({
+      method: "POST",
+      url: "/orders",
+      headers: { authorization: `Bearer ${waiter.accessToken}` },
+      payload: { tableId, items: [{ menuItemId, quantity: 1 }] },
+    });
+    const orderId = (create.json() as { id: number }).id;
+
+    const print = await app.inject({
+      method: "POST",
+      url: `/orders/${orderId}/print`,
+      headers: { authorization: `Bearer ${waiter.accessToken}` },
+    });
+
+    assert.equal(print.statusCode, 200);
+    const body = print.json() as {
+      printingEnabled: boolean;
+      results: Array<{ status: string; code?: string }>;
+    };
+    assert.equal(body.printingEnabled, true);
+    assert.equal(body.results.length, 1);
+    assert.equal(body.results[0].status, "skipped");
+    assert.equal(body.results[0].code, "NO_PRINTER_ASSIGNED");
+  },
+);
+
+test(
+  "POST /orders/:orderId/print is a no-op when order.printTickets is false",
+  { concurrency: false },
+  async () => {
+    const eventPasscode = "print-disabled-pass";
+    const created = createActiveDbFixture({
+      eventName: createEventPrefix("orders-print-disabled"),
+      eventPasscode,
+      adminUsername: "chef",
+      adminPassword: "secret123",
+    }).event;
+    const { tableId, menuItemId } = seedSchemaAndData(created.dbFilePath, {
+      assignPrinter: false,
+    });
+
+    const app = await createAppFixture(buildApp);
+    const auth = createAuthFixture(app);
+    const adminToken = await auth.loginAdmin({
+      eventId: created.id,
+      username: "chef",
+      password: "secret123",
+    });
+    const waiter = await auth.loginWaiter({
+      username: "disabled-waiter",
+      eventPasscode,
+    });
+
+    const patchConfig = await app.inject({
+      method: "PATCH",
+      url: "/config",
+      headers: { authorization: `Bearer ${adminToken}` },
+      payload: { values: { "order.printTickets": "false" } },
+    });
+    assert.equal(patchConfig.statusCode, 200);
+
+    const create = await app.inject({
+      method: "POST",
+      url: "/orders",
+      headers: { authorization: `Bearer ${waiter.accessToken}` },
+      payload: { tableId, items: [{ menuItemId, quantity: 1 }] },
+    });
+    const orderId = (create.json() as { id: number }).id;
+
+    const print = await app.inject({
+      method: "POST",
+      url: `/orders/${orderId}/print`,
+      headers: { authorization: `Bearer ${waiter.accessToken}` },
+    });
+
+    assert.equal(print.statusCode, 200);
+    const body = print.json() as {
+      printingEnabled: boolean;
+      results: unknown[];
+    };
+    assert.equal(body.printingEnabled, false);
+    assert.equal(body.results.length, 0);
+  },
+);
+
+test(
+  "waiter cannot print another waiter's order",
+  { concurrency: false },
+  async () => {
+    const eventPasscode = "print-foreign-pass";
+    const created = createActiveDbFixture({
+      eventName: createEventPrefix("orders-print-foreign"),
+      eventPasscode,
+      adminUsername: "chef",
+      adminPassword: "secret123",
+    }).event;
+    const { tableId, menuItemId } = seedSchemaAndData(created.dbFilePath, {
+      assignPrinter: false,
+    });
+
+    const app = await createAppFixture(buildApp);
+    const auth = createAuthFixture(app);
+    const waiterA = await auth.loginWaiter({
+      username: "foreign-waiter-a",
+      eventPasscode,
+    });
+    const waiterB = await auth.loginWaiter({
+      username: "foreign-waiter-b",
+      eventPasscode,
+    });
+
+    const create = await app.inject({
+      method: "POST",
+      url: "/orders",
+      headers: { authorization: `Bearer ${waiterA.accessToken}` },
+      payload: { tableId, items: [{ menuItemId, quantity: 1 }] },
+    });
+    const orderId = (create.json() as { id: number }).id;
+
+    const forbidden = await app.inject({
+      method: "POST",
+      url: `/orders/${orderId}/print`,
+      headers: { authorization: `Bearer ${waiterB.accessToken}` },
+    });
+
+    assert.equal(forbidden.statusCode, 403);
+    assert.equal(forbidden.json().error.code, "FORBIDDEN");
+  },
+);
+
+test(
+  "POST /orders/:orderId/print returns 404 for unknown order",
+  { concurrency: false },
+  async () => {
+    const eventPasscode = "print-404-pass";
+    createActiveDbFixture({
+      eventName: createEventPrefix("orders-print-404"),
+      eventPasscode,
+      adminUsername: "chef",
+      adminPassword: "secret123",
+    });
+
+    const app = await createAppFixture(buildApp);
+    const auth = createAuthFixture(app);
+    const waiter = await auth.loginWaiter({
+      username: "missing-waiter",
+      eventPasscode,
+    });
+
+    const response = await app.inject({
+      method: "POST",
+      url: "/orders/9999999/print",
+      headers: { authorization: `Bearer ${waiter.accessToken}` },
+    });
+    assert.equal(response.statusCode, 404);
+    assert.equal(response.json().error.code, "ORDER_NOT_FOUND");
+  },
+);

--- a/apps/api/src/routes/orders.ts
+++ b/apps/api/src/routes/orders.ts
@@ -3,6 +3,7 @@
   OrderGetResponseSchema,
   OrderParams,
   OrderParamsSchema,
+  OrderPrintResponseSchema,
   OrdersQuery,
   OrdersQuerySchema,
   OrdersResponseSchema,
@@ -12,7 +13,21 @@
 } from "@serva/shared-types";
 import type { FastifyInstance } from "fastify";
 import { ApiError } from "../domain/api-error";
-import { orderStore } from "../domain/state";
+import { configStore, orderStore, printerStore } from "../domain/state";
+
+// Default to "auto print on" — matches the issue acceptance criteria. The
+// admin can flip the `order.printTickets` config to "false" to disable.
+function isPrintingEnabled(): boolean {
+  try {
+    const values = configStore.listValues();
+    const raw = values["order.printTickets"];
+    if (raw === undefined) return true;
+    return raw.trim().toLowerCase() !== "false";
+  } catch {
+    // No active event → guard handles it before we get here.
+    return true;
+  }
+}
 
 export function registerOrderRoutes(app: FastifyInstance) {
   app.get<{ Querystring: OrdersQuery }>(
@@ -91,6 +106,55 @@ export function registerOrderRoutes(app: FastifyInstance) {
         username: request.auth.username,
       });
       return reply.status(201).send(created);
+    }
+  );
+
+  app.post<{ Params: OrderParams }>(
+    "/orders/:orderId/print",
+    {
+      config: {
+        requiresAuth: true,
+        requiresActiveEvent: true,
+      },
+      schema: {
+        tags: ["orders"],
+        operationId: "ordersPrint",
+        summary: "Bestellung drucken",
+        description:
+          "Druckt die Bons fuer eine Bestellung. Items werden nach zugewiesenem Drucker gruppiert. Wenn order.printTickets=false ist der Lauf no-op (printingEnabled=false). Pro Drucker wird ein Ergebnis zurueckgegeben — ein offline Drucker laesst die anderen Bons trotzdem laufen.",
+        security: [{ bearerAuth: [] }],
+        params: OrderParamsSchema,
+        response: {
+          200: OrderPrintResponseSchema,
+          401: ApiErrorEnvelopeSchema,
+          403: ApiErrorEnvelopeSchema,
+          404: ApiErrorEnvelopeSchema,
+          409: ApiErrorEnvelopeSchema,
+          423: ApiErrorEnvelopeSchema,
+        },
+      },
+    },
+    async (request) => {
+      if (request.auth.role === "master") {
+        throw new ApiError(403, "FORBIDDEN", "Only waiter/admin roles can print orders");
+      }
+
+      // Reuse the existing ownership/lock checks: waiters can only print their
+      // own orders. Throws 404 if the order doesn't exist.
+      orderStore.getOrder(request.params.orderId, {
+        role: request.auth.role,
+        username: request.auth.username,
+      });
+
+      if (!isPrintingEnabled()) {
+        return {
+          orderId: request.params.orderId,
+          printingEnabled: false,
+          results: [],
+        };
+      }
+
+      return printerStore.printOrder(request.params.orderId);
     }
   );
 

--- a/apps/waiter-web/src/index.css
+++ b/apps/waiter-web/src/index.css
@@ -2357,3 +2357,150 @@ body {
 .reorder-feedback--error {
   color: var(--color-danger);
 }
+
+/* ─── Print result modal ─────────────────────────────────────── */
+.print-modal-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 60;
+  background: rgba(0, 0, 0, 0.6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 16px;
+}
+
+.print-modal {
+  width: 100%;
+  max-width: 460px;
+  max-height: calc(100vh - 32px);
+  background: var(--color-bg);
+  border-radius: var(--radius);
+  border: 1px solid var(--color-border);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.print-modal--ok {
+  border-top: 4px solid var(--color-accent);
+}
+
+.print-modal--err {
+  border-top: 4px solid var(--color-danger);
+}
+
+.print-modal__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.print-modal__header h3 {
+  font-size: 18px;
+  font-weight: 600;
+}
+
+.print-modal__close {
+  background: none;
+  border: none;
+  color: var(--color-text);
+  font-size: 24px;
+  line-height: 1;
+  cursor: pointer;
+  padding: 4px 8px;
+}
+
+.print-modal__body {
+  padding: 16px;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.print-modal__status {
+  font-size: 16px;
+  font-weight: 600;
+}
+
+.print-modal__run-label {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--color-text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  margin-bottom: 6px;
+}
+
+.print-modal__results {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.print-modal__result {
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius);
+  padding: 8px 10px;
+  background: var(--color-surface);
+}
+
+.print-modal__result--error {
+  border-color: var(--color-danger);
+}
+
+.print-modal__result-line {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 15px;
+}
+
+.print-modal__result-icon {
+  font-weight: 700;
+}
+
+.print-modal__result--ok .print-modal__result-icon {
+  color: var(--color-accent);
+}
+
+.print-modal__result--error .print-modal__result-icon {
+  color: var(--color-danger);
+}
+
+.print-modal__result-name {
+  flex: 1;
+  font-weight: 600;
+}
+
+.print-modal__result-count {
+  color: var(--color-text-muted);
+  font-size: 13px;
+}
+
+.print-modal__result-msg {
+  margin-top: 4px;
+  font-size: 13px;
+  color: var(--color-text-muted);
+}
+
+.print-modal__hint,
+.print-modal__error {
+  font-size: 14px;
+  color: var(--color-text-muted);
+}
+
+.print-modal__error {
+  color: var(--color-danger);
+}
+
+.print-modal__footer {
+  padding: 12px 16px;
+  border-top: 1px solid var(--color-border);
+  display: flex;
+  justify-content: flex-end;
+}

--- a/apps/waiter-web/src/pages/OrderPage.tsx
+++ b/apps/waiter-web/src/pages/OrderPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { useLocation, useNavigate, useParams } from 'react-router-dom'
 import {
   ApiAuthError,
@@ -8,9 +8,34 @@ import {
   ApiNotFoundError,
   ApiValidationError,
 } from '@serva/api-client'
+import type { OrderPrintResultDto } from '@serva/shared-types'
 import { useApiClient } from '../hooks/useApiClient'
 import { useCart } from '../contexts/CartContext'
 import type { CartLine } from '../contexts/CartContext'
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface PrintRunResult {
+  /** Display label for which order this run covers ("Bestellung" / "Extras"). */
+  label: string
+  /** False when the API reports `order.printTickets` is disabled. */
+  printingEnabled: boolean
+  /** Per-printer results (empty when printing is disabled or the call threw). */
+  results: OrderPrintResultDto[]
+  /** Set when the print API call itself failed (network/server error). */
+  error: string | null
+}
+
+interface PrintResultModalState {
+  title: string
+  /** True when every run reports printingEnabled. */
+  printingEnabled: boolean
+  /** True when no run had an error and every printer result is ok/skipped. */
+  allOk: boolean
+  runs: PrintRunResult[]
+}
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -98,9 +123,13 @@ export function OrderPage() {
 
   const [submitting, setSubmitting] = useState(false)
   const [submitError, setSubmitError] = useState<string | null>(null)
-  const [toastMessage, setToastMessage] = useState<string | null>(null)
   // menuItemId → error kind for inline per-row highlighting
   const [itemErrors, setItemErrors] = useState<Map<number, 'locked' | 'notFound'>>(new Map())
+
+  // Result modal — set once orders are submitted (and print attempted). Holds
+  // the combined per-bon outcome so the waiter sees a single confirmation
+  // covering both the regular and the extras orders.
+  const [printResult, setPrintResult] = useState<PrintResultModalState | null>(null)
 
   // Extras accordion open state — auto-open when extras exist
   const [extrasOpen, setExtrasOpen] = useState(false)
@@ -159,29 +188,74 @@ export function OrderPage() {
     const hasExtra = extraLines.length > 0
 
     try {
+      const created: Array<{ orderId: number; label: string }> = []
+
       if (hasRegular) {
-        await client.orders.create({
+        const order = await client.orders.create({
           tableId: tableIdNum,
           items: toOrderItems(regularLines),
         })
+        created.push({ orderId: order.id, label: 'Bestellung' })
       }
 
       if (hasExtra) {
-        await client.orders.create({
+        const order = await client.orders.create({
           tableId: tableIdNum,
           items: toOrderItems(extraLines),
         })
+        created.push({ orderId: order.id, label: 'Extras' })
       }
 
+      // Cart is cleared eagerly: the orders are persisted server-side, so
+      // even if printing fails the waiter shouldn't re-submit them.
       clearCart()
-      const msg =
-        hasRegular && hasExtra
-          ? 'Bestellung & Extras aufgegeben!'
-          : hasExtra
-          ? 'Extras aufgegeben!'
-          : 'Bestellung aufgegeben!'
-      setToastMessage(msg)
-      setTimeout(() => navigate('/tables', { replace: true }), 1500)
+
+      // Print every created order in parallel. A printer outage on one bon
+      // shouldn't hold up the others — failures land in `results` per group.
+      const printRuns = await Promise.all(
+        created.map(async (entry) => {
+          try {
+            const res = await client.orders.print(entry.orderId)
+            return {
+              label: entry.label,
+              printingEnabled: res.printingEnabled,
+              results: res.results,
+              error: null as string | null,
+            }
+          } catch (err) {
+            return {
+              label: entry.label,
+              printingEnabled: true,
+              results: [] as OrderPrintResultDto[],
+              error:
+                err instanceof Error
+                  ? err.message
+                  : 'Druckauftrag fehlgeschlagen.',
+            }
+          }
+        }),
+      )
+
+      const printingEnabled = printRuns.every((r) => r.printingEnabled)
+      const allOk =
+        printRuns.every((r) => r.error === null) &&
+        printRuns.every((r) =>
+          r.results.every((it) => it.status !== 'error'),
+        )
+
+      setPrintResult({
+        title:
+          hasRegular && hasExtra
+            ? 'Bestellung & Extras aufgegeben'
+            : hasExtra
+            ? 'Extras aufgegeben'
+            : 'Bestellung aufgegeben',
+        printingEnabled,
+        allOk,
+        runs: printRuns,
+      })
+      setSubmitting(false)
+      return
     } catch (err) {
       // ── Per-item inline errors ───────────────────────────────────────────
       const newItemErrors = new Map<number, 'locked' | 'notFound'>()
@@ -244,9 +318,16 @@ export function OrderPage() {
     </div>
   )
 
+  // ── Result modal close ─────────────────────────────────────────────────
+
+  const handleCloseResult = useCallback(() => {
+    setPrintResult(null)
+    navigate('/tables', { replace: true })
+  }, [navigate])
+
   // ── Empty cart ─────────────────────────────────────────────────────────
 
-  if (lineList.length === 0 && !toastMessage) {
+  if (lineList.length === 0 && !printResult) {
     return (
       <div className="page order-page">
         {header}
@@ -259,10 +340,8 @@ export function OrderPage() {
 
   return (
     <div className="page order-page">
-      {toastMessage && (
-        <div className="order-toast order-toast--success" role="status">
-          &#10003;&nbsp;{toastMessage}
-        </div>
+      {printResult && (
+        <PrintResultModal state={printResult} onClose={handleCloseResult} />
       )}
 
       {header}
@@ -576,5 +655,116 @@ function CartItemRow({
         />
       </label>
     </li>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Print result modal
+// ---------------------------------------------------------------------------
+
+interface PrintResultModalProps {
+  state: PrintResultModalState
+  onClose: () => void
+}
+
+function PrintResultModal({ state, onClose }: PrintResultModalProps) {
+  // Auto-dismiss when everything succeeded so the waiter can move on quickly.
+  // Failures stay open until the user acknowledges.
+  useEffect(() => {
+    if (!state.allOk) return
+    const timer = setTimeout(onClose, 2200)
+    return () => clearTimeout(timer)
+  }, [state.allOk, onClose])
+
+  const headerLabel = !state.printingEnabled
+    ? 'Bondrucke deaktiviert'
+    : state.allOk
+    ? 'Bons gedruckt'
+    : 'Druck mit Fehlern'
+
+  return (
+    <div
+      className="print-modal-backdrop"
+      role="dialog"
+      aria-modal="true"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onClose()
+      }}
+    >
+      <div className={`print-modal print-modal--${state.allOk ? 'ok' : 'err'}`}>
+        <div className="print-modal__header">
+          <h3>{state.title}</h3>
+          <button
+            type="button"
+            className="print-modal__close"
+            onClick={onClose}
+            aria-label="Schliessen"
+          >
+            &times;
+          </button>
+        </div>
+
+        <div className="print-modal__body">
+          <p className="print-modal__status">
+            {state.allOk ? '✓ ' : '⚠ '}
+            {headerLabel}
+          </p>
+
+          {state.runs.map((run, runIdx) => (
+            <div key={runIdx} className="print-modal__run">
+              <div className="print-modal__run-label">{run.label}</div>
+              {run.error ? (
+                <p className="print-modal__error">
+                  Druckauftrag fehlgeschlagen: {run.error}
+                </p>
+              ) : !run.printingEnabled ? (
+                <p className="print-modal__hint">
+                  Bondrucke sind deaktiviert. Bestellung wurde gespeichert.
+                </p>
+              ) : run.results.length === 0 ? (
+                <p className="print-modal__hint">Keine Bons fuer diesen Auftrag.</p>
+              ) : (
+                <ul className="print-modal__results">
+                  {run.results.map((result, idx) => (
+                    <li
+                      key={idx}
+                      className={`print-modal__result print-modal__result--${result.status}`}
+                    >
+                      <div className="print-modal__result-line">
+                        <span className="print-modal__result-icon" aria-hidden="true">
+                          {result.status === 'ok'
+                            ? '✓'
+                            : result.status === 'skipped'
+                            ? '–'
+                            : '✗'}
+                        </span>
+                        <span className="print-modal__result-name">
+                          {result.printerName}
+                        </span>
+                        <span className="print-modal__result-count">
+                          {result.itemCount}&nbsp;Pos.
+                        </span>
+                      </div>
+                      {result.status !== 'ok' && (
+                        <div className="print-modal__result-msg">
+                          {result.message}
+                          {result.hint ? ` — ${result.hint}` : ''}
+                        </div>
+                      )}
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
+          ))}
+        </div>
+
+        <div className="print-modal__footer">
+          <button type="button" className="btn-primary" onClick={onClose}>
+            {state.allOk ? 'Weiter' : 'Verstanden'}
+          </button>
+        </div>
+      </div>
+    </div>
   )
 }

--- a/packages/api-client/src/routes/orders.ts
+++ b/packages/api-client/src/routes/orders.ts
@@ -1,9 +1,11 @@
 import {
   OrderGetResponseSchema,
+  OrderPrintResponseSchema,
   OrdersResponseSchema,
   OrderSubmitRequestSchema,
   OrderSubmitResponseSchema,
   type OrderGetResponse,
+  type OrderPrintResponse,
   type OrdersQuery,
   type OrdersResponse,
   type OrderSubmitRequest,
@@ -15,6 +17,12 @@ export interface OrdersClient {
   list(query?: OrdersQuery): Promise<OrdersResponse>;
   create(body: OrderSubmitRequest): Promise<OrderSubmitResponse>;
   getById(orderId: number): Promise<OrderGetResponse>;
+  /**
+   * Trigger printing of an order's bons. The API groups items by their
+   * category's assigned printer and returns one result per printer. A failed
+   * printer doesn't fail the call — inspect `results[].status` instead.
+   */
+  print(orderId: number): Promise<OrderPrintResponse>;
 }
 
 export function createOrdersClient(http: HttpTransport): OrdersClient {
@@ -36,5 +44,8 @@ export function createOrdersClient(http: HttpTransport): OrdersClient {
 
     getById: (orderId) =>
       http.get(OrderGetResponseSchema, `/orders/${orderId}`),
+
+    print: (orderId) =>
+      http.post(OrderPrintResponseSchema, `/orders/${orderId}/print`),
   };
 }

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -915,6 +915,35 @@ export type OrdersResponse = z.infer<typeof OrdersResponseSchema>;
 export const OrderGetResponseSchema = OrderDtoSchema;
 export type OrderGetResponse = OrderDto;
 
+// ─── Order printing ─────────────────────────────────────────────────────────
+// A waiter submits an order, then triggers a print run. The API groups the
+// order's items by their menu category's assigned printer and sends one bon
+// per printer. The response carries a per-printer result so the waiter UI can
+// surface partial failures (one printer offline doesn't fail the whole run).
+
+export const OrderPrintResultDtoSchema = z
+  .object({
+    printerId: positiveInt.optional(),
+    printerName: z.string(),
+    status: z.enum(["ok", "error", "skipped"]),
+    itemCount: z.number().int().nonnegative(),
+    message: z.string(),
+    code: z.string().optional(),
+    target: z.string().optional(),
+    hint: z.string().optional(),
+  })
+  .strict();
+export type OrderPrintResultDto = z.infer<typeof OrderPrintResultDtoSchema>;
+
+export const OrderPrintResponseSchema = z
+  .object({
+    orderId: positiveInt,
+    printingEnabled: z.boolean(),
+    results: z.array(OrderPrintResultDtoSchema),
+  })
+  .strict();
+export type OrderPrintResponse = z.infer<typeof OrderPrintResponseSchema>;
+
 export const ApiErrorEnvelopeSchema = z
   .object({
     error: z


### PR DESCRIPTION
## Summary
- New API endpoint `POST /orders/:orderId/print` groups order items by their menu category's assigned printer and sends one ESC/POS bon per printer. Special-request items collapse to a single quad-area line prefixed with `*`.
- waiter-web fires prints in parallel after order submit and surfaces per-bon results in a modal so a single printer outage doesn't block the others.
- Small UX add: back button on the admin-desktop login page.

## Test plan
- [ ] `cd apps/api && pnpm test` (covers `orders.print.test.ts` — happy path, no-printer skip, disabled config, foreign-waiter 403, unknown-order 404)
- [ ] Manually submit an order in waiter-web against a live printer and confirm the bon layout
- [ ] Submit an order with a special request and confirm the line renders as `*Nx <request>`
- [ ] Toggle `order.printTickets=false` in admin config and confirm the run is a no-op

Closes Serva-91

🤖 Generated with [Claude Code](https://claude.com/claude-code)