### PR TITLE
Serva-93 feat(api,admin-desktop): backend log viewer

### DIFF
--- a/apps/admin-desktop/src/App.css
+++ b/apps/admin-desktop/src/App.css
@@ -2033,3 +2033,113 @@ html, body, #root {
   .orders-row--expanded:hover { background: rgba(99,102,241,0.18); }
   .orders-detail { background: #111827; }
 }
+
+/* ============================================================
+   Logs page
+   ============================================================ */
+.logs-page {
+  display: flex;
+  flex-direction: column;
+  height: calc(100vh - 80px);
+}
+
+.logs-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.logs-search {
+  width: 220px;
+}
+
+.logs-level-select {
+  width: auto;
+  min-width: 120px;
+}
+
+.logs-auto {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 13px;
+  color: var(--color-muted);
+  white-space: nowrap;
+}
+
+.logs-viewport {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  background: #0b1020;
+  color: #e5e7eb;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+  font-size: 12px;
+  padding: 6px 0;
+}
+
+.logs-empty {
+  padding: 24px;
+  text-align: center;
+  color: #94a3b8;
+}
+
+.log-row {
+  display: grid;
+  grid-template-columns: 110px 78px 1fr;
+  gap: 10px;
+  padding: 3px 12px;
+  border-left: 3px solid transparent;
+  align-items: baseline;
+}
+
+.log-row:hover { background: rgba(255,255,255,0.04); }
+
+.log-time { color: #94a3b8; white-space: nowrap; }
+.log-level {
+  font-weight: 600;
+  text-transform: uppercase;
+  font-size: 10.5px;
+  letter-spacing: 0.06em;
+}
+.log-msg { white-space: pre-wrap; word-break: break-word; }
+.log-context {
+  grid-column: 3 / 4;
+  color: #94a3b8;
+  font-size: 11px;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.log-row--trace { color: #94a3b8; }
+.log-row--trace .log-level { color: #94a3b8; }
+
+.log-row--debug { color: #cbd5e1; }
+.log-row--debug .log-level { color: #93c5fd; }
+
+.log-row--info { color: #e5e7eb; }
+.log-row--info .log-level { color: #60a5fa; }
+
+.log-row--warn {
+  color: #fde68a;
+  background: rgba(234, 179, 8, 0.08);
+  border-left-color: #f59e0b;
+}
+.log-row--warn .log-level { color: #fbbf24; }
+
+.log-row--error {
+  color: #fecaca;
+  background: rgba(239, 68, 68, 0.10);
+  border-left-color: #ef4444;
+}
+.log-row--error .log-level { color: #f87171; }
+
+.log-row--fatal {
+  color: #fecaca;
+  background: rgba(239, 68, 68, 0.18);
+  border-left-color: #b91c1c;
+}
+.log-row--fatal .log-level { color: #f87171; }

--- a/apps/admin-desktop/src/App.tsx
+++ b/apps/admin-desktop/src/App.tsx
@@ -14,6 +14,7 @@ import { UsersPage } from "./pages/UsersPage";
 import { StockPage } from "./pages/StockPage";
 import { ConfigPage } from "./pages/ConfigPage";
 import { OrdersPage } from "./pages/OrdersPage";
+import { LogsPage } from "./pages/LogsPage";
 import "./App.css";
 
 // ---------------------------------------------------------------------------
@@ -104,6 +105,7 @@ function AppRoutes() {
           <Route path="stock"          element={<StockPage />} />
           <Route path="config"         element={<ConfigPage />} />
           <Route path="orders"         element={<OrdersPage />} />
+          <Route path="logs"           element={<LogsPage />} />
         </Route>
       </Route>
 

--- a/apps/admin-desktop/src/components/AdminShell.tsx
+++ b/apps/admin-desktop/src/components/AdminShell.tsx
@@ -11,6 +11,7 @@ const NAV_ITEMS = [
   { segment: "users",          label: "Benutzer" },
   { segment: "stock",          label: "Lager" },
   { segment: "orders",         label: "Bestellungen" },
+  { segment: "logs",           label: "Logs" },
   { segment: "config",         label: "Einstellungen" },
 ] as const;
 

--- a/apps/admin-desktop/src/pages/LogsPage.tsx
+++ b/apps/admin-desktop/src/pages/LogsPage.tsx
@@ -1,0 +1,203 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import type { LogEntryDto, LogLevel } from "@serva/shared-types";
+import { useApiClient } from "../contexts/ApiClientContext";
+
+// Display labels mirror the German UI copy in the rest of the admin app.
+const LEVEL_LABEL: Record<LogLevel, string> = {
+  trace: "Trace",
+  debug: "Debug",
+  info: "Info",
+  warn: "Warnung",
+  error: "Fehler",
+  fatal: "Fatal",
+};
+
+const LEVEL_OPTIONS: ReadonlyArray<{ value: LogLevel; label: string }> = [
+  { value: "trace", label: "Alle" },
+  { value: "debug", label: "Debug+" },
+  { value: "info", label: "Info+" },
+  { value: "warn", label: "Warnung+" },
+  { value: "error", label: "Fehler+" },
+];
+
+const POLL_INTERVAL_MS = 2000;
+const MAX_ENTRIES = 1000;
+
+type LoadState =
+  | { status: "loading" }
+  | { status: "error"; message: string }
+  | { status: "ok" };
+
+function formatTime(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return iso;
+  const hh = String(d.getHours()).padStart(2, "0");
+  const mm = String(d.getMinutes()).padStart(2, "0");
+  const ss = String(d.getSeconds()).padStart(2, "0");
+  const ms = String(d.getMilliseconds()).padStart(3, "0");
+  return `${hh}:${mm}:${ss}.${ms}`;
+}
+
+function formatContext(ctx: Record<string, unknown> | undefined): string {
+  if (!ctx) return "";
+  try {
+    return JSON.stringify(ctx);
+  } catch {
+    return "";
+  }
+}
+
+export function LogsPage() {
+  const api = useApiClient();
+  const [entries, setEntries] = useState<LogEntryDto[]>([]);
+  const [state, setState] = useState<LoadState>({ status: "loading" });
+  const [minLevel, setMinLevel] = useState<LogLevel>("info");
+  const [autoRefresh, setAutoRefresh] = useState(true);
+  const [search, setSearch] = useState("");
+
+  // We tear down/recreate the poll timer whenever the level filter or
+  // auto-refresh toggle flips, so a stale interval can't keep running.
+  const lastIdRef = useRef(0);
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  const fetchOnce = useCallback(
+    async (mode: "refresh" | "poll") => {
+      try {
+        if (mode === "refresh") {
+          setState({ status: "loading" });
+        }
+        const res = await api.logs.list(
+          mode === "poll"
+            ? { since: lastIdRef.current, minLevel }
+            : { minLevel, limit: MAX_ENTRIES },
+        );
+        if (mode === "refresh") {
+          setEntries(res.entries);
+          lastIdRef.current = res.lastId;
+        } else if (res.entries.length > 0) {
+          setEntries((prev) => {
+            const merged = [...prev, ...res.entries];
+            return merged.length > MAX_ENTRIES
+              ? merged.slice(merged.length - MAX_ENTRIES)
+              : merged;
+          });
+          lastIdRef.current = res.lastId;
+        }
+        setState({ status: "ok" });
+      } catch (err) {
+        setState({
+          status: "error",
+          message: err instanceof Error ? err.message : "Fehler beim Laden.",
+        });
+      }
+    },
+    [api, minLevel],
+  );
+
+  // Initial load and reload on level change.
+  useEffect(() => {
+    void fetchOnce("refresh");
+  }, [fetchOnce]);
+
+  // Poll loop.
+  useEffect(() => {
+    if (!autoRefresh) return;
+    const timer = setInterval(() => {
+      void fetchOnce("poll");
+    }, POLL_INTERVAL_MS);
+    return () => clearInterval(timer);
+  }, [autoRefresh, fetchOnce]);
+
+  // Stick the viewport to the latest entry whenever new lines arrive — but
+  // only if the user is already near the bottom, so a scrolled-up reader
+  // isn't yanked back down mid-read.
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    const distanceFromBottom = el.scrollHeight - el.scrollTop - el.clientHeight;
+    if (distanceFromBottom < 120) {
+      el.scrollTop = el.scrollHeight;
+    }
+  }, [entries]);
+
+  const filtered = useMemo(() => {
+    if (!search.trim()) return entries;
+    const needle = search.trim().toLowerCase();
+    return entries.filter((e) => {
+      if (e.msg.toLowerCase().includes(needle)) return true;
+      if (e.context && formatContext(e.context).toLowerCase().includes(needle)) {
+        return true;
+      }
+      return false;
+    });
+  }, [entries, search]);
+
+  return (
+    <div className="logs-page">
+      <div className="page-header">
+        <h1 className="page-title">Logs</h1>
+        <div className="logs-toolbar">
+          <input
+            className="form-input logs-search"
+            type="search"
+            placeholder="Filter…"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+          />
+          <select
+            className="form-input logs-level-select"
+            value={minLevel}
+            onChange={(e) => setMinLevel(e.target.value as LogLevel)}
+          >
+            {LEVEL_OPTIONS.map((opt) => (
+              <option key={opt.value} value={opt.value}>
+                {opt.label}
+              </option>
+            ))}
+          </select>
+          <label className="logs-auto">
+            <input
+              type="checkbox"
+              checked={autoRefresh}
+              onChange={(e) => setAutoRefresh(e.target.checked)}
+            />
+            Auto-Refresh
+          </label>
+          <button
+            type="button"
+            className="btn-secondary"
+            onClick={() => void fetchOnce("refresh")}
+          >
+            Aktualisieren
+          </button>
+        </div>
+      </div>
+
+      {state.status === "error" && (
+        <p className="form-error">{state.message}</p>
+      )}
+
+      <div className="logs-viewport" ref={scrollRef}>
+        {filtered.length === 0 ? (
+          <div className="logs-empty">
+            {state.status === "loading" ? "Wird geladen…" : "Keine Eintraege."}
+          </div>
+        ) : (
+          filtered.map((entry) => (
+            <div
+              key={entry.id}
+              className={`log-row log-row--${entry.level}`}
+            >
+              <span className="log-time">{formatTime(entry.time)}</span>
+              <span className="log-level">{LEVEL_LABEL[entry.level]}</span>
+              <span className="log-msg">{entry.msg || "—"}</span>
+              {entry.context && (
+                <span className="log-context">{formatContext(entry.context)}</span>
+              )}
+            </div>
+          ))
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -15,6 +15,8 @@ import {
 import { registerActiveEventGuard } from "./plugins/active-event-guard";
 import { registerErrorHandler } from "./plugins/error-handler";
 import { registerJwtAuthGuard } from "./plugins/jwt-auth-guard";
+import { createLogBufferStream, logBuffer } from "./plugins/log-buffer";
+import { registerLogRoutes } from "./routes/logs";
 import { registerAdminEventRoutes } from "./routes/admin-events";
 import { registerAuthRoutes } from "./routes/auth";
 import { registerConfigRoutes } from "./routes/config";
@@ -96,7 +98,10 @@ interface BuildAppOptions {
 
 export async function buildApp(options: BuildAppOptions = {}) {
   const app = Fastify({
-    logger: true,
+    logger: {
+      level: process.env.LOG_LEVEL ?? "info",
+      stream: createLogBufferStream(logBuffer),
+    },
     ...(options.serverFactory ? { serverFactory: options.serverFactory } : {}),
   }).withTypeProvider<ZodTypeProvider>();
 
@@ -225,6 +230,7 @@ export async function buildApp(options: BuildAppOptions = {}) {
   registerOrderDisplayRoutes(app);
   registerStockRoutes(app);
   registerTableRoutes(app);
+  registerLogRoutes(app, logBuffer);
 
   return app;
 }

--- a/apps/api/src/plugins/log-buffer.ts
+++ b/apps/api/src/plugins/log-buffer.ts
@@ -1,0 +1,128 @@
+import { Writable } from "node:stream";
+import type { LogEntryDto, LogLevel } from "@serva/shared-types";
+
+// Pino's numeric levels.
+const LEVEL_NAMES: Record<number, LogLevel> = {
+  10: "trace",
+  20: "debug",
+  30: "info",
+  40: "warn",
+  50: "error",
+  60: "fatal",
+};
+
+// Keys we strip from the captured pino payload before exposing it as the
+// `context` map — they're either redundant (already promoted to top-level
+// fields) or noisy boilerplate (pid/hostname).
+const STRIPPED_KEYS = new Set([
+  "level",
+  "time",
+  "msg",
+  "pid",
+  "hostname",
+  "v",
+]);
+
+interface RawEntry {
+  level?: number;
+  time?: number;
+  msg?: string;
+  [key: string]: unknown;
+}
+
+export class LogBuffer {
+  private readonly capacity: number;
+  private readonly entries: LogEntryDto[] = [];
+  private nextId = 1;
+
+  constructor(capacity = 1000) {
+    this.capacity = capacity;
+  }
+
+  push(raw: RawEntry): void {
+    const levelNum = typeof raw.level === "number" ? raw.level : 30;
+    const level = LEVEL_NAMES[levelNum] ?? "info";
+    const timeMs = typeof raw.time === "number" ? raw.time : Date.now();
+
+    const context: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(raw)) {
+      if (!STRIPPED_KEYS.has(key)) {
+        context[key] = value;
+      }
+    }
+
+    const entry: LogEntryDto = {
+      id: this.nextId++,
+      time: new Date(timeMs).toISOString(),
+      level,
+      msg: typeof raw.msg === "string" ? raw.msg : "",
+      ...(Object.keys(context).length > 0 ? { context } : {}),
+    };
+
+    this.entries.push(entry);
+    if (this.entries.length > this.capacity) {
+      this.entries.splice(0, this.entries.length - this.capacity);
+    }
+  }
+
+  query(opts: { since?: number; minLevel?: LogLevel; limit?: number }): {
+    entries: LogEntryDto[];
+    lastId: number;
+  } {
+    const lastId = this.entries.length === 0
+      ? 0
+      : this.entries[this.entries.length - 1].id;
+
+    const minRank = opts.minLevel ? rankOf(opts.minLevel) : 0;
+    const limit = opts.limit ?? 500;
+
+    const filtered: LogEntryDto[] = [];
+    for (const entry of this.entries) {
+      if (opts.since !== undefined && entry.id <= opts.since) continue;
+      if (rankOf(entry.level) < minRank) continue;
+      filtered.push(entry);
+    }
+
+    const sliced = filtered.length > limit ? filtered.slice(-limit) : filtered;
+    return { entries: sliced, lastId };
+  }
+}
+
+const LEVEL_RANK: Record<LogLevel, number> = {
+  trace: 10,
+  debug: 20,
+  info: 30,
+  warn: 40,
+  error: 50,
+  fatal: 60,
+};
+
+function rankOf(level: LogLevel): number {
+  return LEVEL_RANK[level] ?? 30;
+}
+
+/**
+ * Creates a Writable stream suitable as Fastify's `logger.stream`. Each chunk
+ * is one pino JSON log line; we parse it into a ring-buffer entry and also
+ * forward the raw line to stdout so console output remains intact.
+ */
+export function createLogBufferStream(buffer: LogBuffer): Writable {
+  return new Writable({
+    write(chunk, _enc, cb) {
+      const line = chunk.toString();
+      process.stdout.write(line);
+      // pino batches multiple log records by newline; handle each separately.
+      for (const part of line.split("\n")) {
+        if (!part) continue;
+        try {
+          buffer.push(JSON.parse(part) as RawEntry);
+        } catch {
+          // Non-JSON output (shouldn't happen from pino) — skip silently.
+        }
+      }
+      cb();
+    },
+  });
+}
+
+export const logBuffer = new LogBuffer();

--- a/apps/api/src/routes/logs.ts
+++ b/apps/api/src/routes/logs.ts
@@ -1,0 +1,36 @@
+import {
+  ApiErrorEnvelopeSchema,
+  LogsQuery,
+  LogsQuerySchema,
+  LogsResponseSchema,
+} from "@serva/shared-types";
+import type { FastifyInstance } from "fastify";
+import type { LogBuffer } from "../plugins/log-buffer";
+
+export function registerLogRoutes(app: FastifyInstance, buffer: LogBuffer) {
+  app.get<{ Querystring: LogsQuery }>(
+    "/logs",
+    {
+      config: {
+        requiresAuth: true,
+        allowedRoles: ["master", "admin"],
+      },
+      schema: {
+        tags: ["ops"],
+        operationId: "getLogs",
+        summary: "Backend-Logs abrufen",
+        description:
+          "Liefert die zuletzt im Backend erzeugten Log-Eintraege (In-Memory-Ringpuffer). " +
+          "Mit ?since=<id> koennen nur neuere Eintraege geholt werden.",
+        security: [{ bearerAuth: [] }],
+        querystring: LogsQuerySchema,
+        response: {
+          200: LogsResponseSchema,
+          401: ApiErrorEnvelopeSchema,
+          403: ApiErrorEnvelopeSchema,
+        },
+      },
+    },
+    async (request) => buffer.query(request.query)
+  );
+}

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -2,6 +2,7 @@ import { HttpTransport } from "./http.js";
 import { createAdminEventsClient, type AdminEventsClient } from "./routes/admin-events.js";
 import { createAuthClient, type AuthClient } from "./routes/auth.js";
 import { createConfigClient, type ConfigClient } from "./routes/config.js";
+import { createLogsClient, type LogsClient } from "./routes/logs.js";
 import { createMenuClient, type MenuClient } from "./routes/menu.js";
 import { createOrdersClient, type OrdersClient } from "./routes/orders.js";
 import {
@@ -21,6 +22,7 @@ export type {
   AdminEventsClient,
   AuthClient,
   ConfigClient,
+  LogsClient,
   MenuClient,
   OrderDisplaysClient,
   OrdersClient,
@@ -66,6 +68,7 @@ export interface ServaApiClient {
   stock: StockClient;
   config: ConfigClient;
   adminEvents: AdminEventsClient;
+  logs: LogsClient;
 }
 
 export function createApiClient(opts: ApiClientOptions): ServaApiClient {
@@ -82,5 +85,6 @@ export function createApiClient(opts: ApiClientOptions): ServaApiClient {
     stock: createStockClient(http),
     config: createConfigClient(http),
     adminEvents: createAdminEventsClient(http),
+    logs: createLogsClient(http),
   };
 }

--- a/packages/api-client/src/routes/logs.ts
+++ b/packages/api-client/src/routes/logs.ts
@@ -1,0 +1,22 @@
+import {
+  LogsResponseSchema,
+  type LogsQuery,
+  type LogsResponse,
+} from "@serva/shared-types";
+import type { HttpTransport, QueryParams } from "../http.js";
+
+export interface LogsClient {
+  list(query?: LogsQuery): Promise<LogsResponse>;
+}
+
+export function createLogsClient(http: HttpTransport): LogsClient {
+  return {
+    list: (query) => {
+      const params: QueryParams = {};
+      if (query?.since !== undefined) params.since = query.since;
+      if (query?.minLevel !== undefined) params.minLevel = query.minLevel;
+      if (query?.limit !== undefined) params.limit = query.limit;
+      return http.get(LogsResponseSchema, "/logs", params);
+    },
+  };
+}

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -944,6 +944,55 @@ export const OrderPrintResponseSchema = z
   .strict();
 export type OrderPrintResponse = z.infer<typeof OrderPrintResponseSchema>;
 
+// ─── Logs ───────────────────────────────────────────────────────────────────
+// Backend log ring-buffer surface. Pino numeric levels are mapped to the
+// canonical names; `id` is a monotonically increasing sequence assigned by the
+// in-memory buffer so the frontend can fetch only newer entries on each poll.
+
+export const LogLevelSchema = z.enum(["trace", "debug", "info", "warn", "error", "fatal"]);
+export type LogLevel = z.infer<typeof LogLevelSchema>;
+
+export const LogEntryDtoSchema = z
+  .object({
+    id: positiveInt,
+    time: z.string().datetime(),
+    level: LogLevelSchema,
+    msg: z.string(),
+    context: z.record(z.string(), z.unknown()).optional(),
+  })
+  .strict();
+export type LogEntryDto = z.infer<typeof LogEntryDtoSchema>;
+
+export const LogsQuerySchema = z
+  .object({
+    since: z.coerce
+      .number()
+      .int()
+      .nonnegative()
+      .optional()
+      .describe("Only return entries with id > since. Example: ?since=42"),
+    minLevel: LogLevelSchema
+      .optional()
+      .describe("Filter to entries at this level or higher. Example: ?minLevel=warn"),
+    limit: z.coerce
+      .number()
+      .int()
+      .positive()
+      .max(1000)
+      .optional()
+      .describe("Max entries to return (default 500)."),
+  })
+  .strict();
+export type LogsQuery = z.infer<typeof LogsQuerySchema>;
+
+export const LogsResponseSchema = z
+  .object({
+    entries: z.array(LogEntryDtoSchema),
+    lastId: z.number().int().nonnegative(),
+  })
+  .strict();
+export type LogsResponse = z.infer<typeof LogsResponseSchema>;
+
 export const ApiErrorEnvelopeSchema = z
   .object({
     error: z


### PR DESCRIPTION
Closes #93.

## Summary
- API now captures every pino log line into an in-memory ring buffer (1000 entries) via a custom Fastify logger stream that also forwards to stdout — no observable change to existing console output.
- New `GET /logs` endpoint (master + admin) returns the buffer with `since`/`minLevel`/`limit` filters, fully typed via `@serva/shared-types` and exposed in `@serva/api-client` as `api.logs.list(...)`.
- New admin page **Logs** (sidebar entry between *Bestellungen* and *Einstellungen*) polls every 2s, colour-codes `warn`/`error`/`fatal`, and adds a text filter and minimum-level selector. Auto-scroll only kicks in when the reader is already near the bottom.

## Test plan
- [ ] `pnpm --filter api test` — passes (2 pre-existing failures on `main` unrelated to this change)
- [ ] `pnpm --filter @serva/api-client test` — 14/14 pass
- [ ] `pnpm build` — all packages build clean
- [ ] Manual: open admin → Logs, perform actions in other tabs, observe new log lines stream in with correct level colours
- [ ] Manual: change "Min. Level" → list rebuilds; toggle Auto-Refresh off → polling stops

🤖 Generated with [Claude Code](https://claude.com/claude-code)