### PR TITLE
Serva-92 fix(waiter-web): move special requests to order screen

### DIFF
--- a/apps/api/src/domain/printer-store.ts
+++ b/apps/api/src/domain/printer-store.ts
@@ -534,15 +534,19 @@ export class PrinterStore {
     printer.drawLine();
 
     for (const item of items) {
-      // Items with a special request collapse to a single line that leads with
-      // `*` and shows the request text in place of the menu item name. The
-      // kitchen scans the asterisk to spot modified items at a glance.
-      const line = item.specialRequests
-        ? `*${item.quantity}x ${item.specialRequests}`
-        : `${item.quantity}x ${item.menuItemName}`;
-      printer.setTextQuadArea();
-      printer.println(line);
-      printer.setTextNormal();
+      if (item.quantity > 0) {
+        printer.setTextQuadArea();
+        printer.println(`${item.quantity}x ${item.menuItemName}`);
+        printer.setTextNormal();
+      }
+      if (item.specialRequests) {
+        for (const sr of item.specialRequests.split("; ")) {
+          if (!sr) continue;
+          printer.setTextQuadArea();
+          printer.println(`*${sr}`);
+          printer.setTextNormal();
+        }
+      }
     }
 
     printer.drawLine();

--- a/apps/waiter-web/src/contexts/CartContext.tsx
+++ b/apps/waiter-web/src/contexts/CartContext.tsx
@@ -12,14 +12,10 @@ import type { MenuItemDto } from '@serva/shared-types'
 // Types
 // ---------------------------------------------------------------------------
 
-export interface SpecialRequest {
-  id: string
-  text: string
-}
-
 export interface CartLine {
   item: MenuItemDto
   qty: number
+  specialRequests: string[]
   /** When true this line is submitted as a separate "extra" order so the
    *  kitchen receives it distinctly from the main order. */
   isExtra: boolean
@@ -30,13 +26,11 @@ export interface CartLine {
 interface CartState {
   tableId: number | null
   lines: Record<number, CartLine>
-  specialRequests: SpecialRequest[]
 }
 
 interface CartContextValue {
   tableId: number | null
   lines: Record<number, CartLine>
-  specialRequests: SpecialRequest[]
   /** Total item count across all lines (sum of quantities). */
   count: number
   /** Grand total in currency units. */
@@ -67,9 +61,9 @@ interface CartContextValue {
   /** Toggles the isExtra flag. */
   toggleExtra(itemId: number): void
 
-  // ── Special requests ────────────────────────────────────────────────────
-  addSpecialRequest(text: string): void
-  removeSpecialRequest(id: string): void
+  // ── Per-item special requests ───────────────────────────────────────────
+  addSpecialRequest(itemId: number, text: string): void
+  removeSpecialRequest(itemId: number, index: number): void
 
   // ── Payment tracking ────────────────────────────────────────────────────
   /**
@@ -93,7 +87,6 @@ const CartContext = createContext<CartContextValue | null>(null)
 const EMPTY_CART: CartState = {
   tableId: null,
   lines: {},
-  specialRequests: [],
 }
 
 export function CartProvider({ children }: { children: ReactNode }) {
@@ -122,6 +115,7 @@ export function CartProvider({ children }: { children: ReactNode }) {
           [item.id]: {
             item,
             qty: (existing?.qty ?? 0) + 1,
+            specialRequests: existing?.specialRequests ?? [],
             isExtra: existing?.isExtra ?? false,
             paidQty: existing?.paidQty ?? 0,
           },
@@ -165,21 +159,38 @@ export function CartProvider({ children }: { children: ReactNode }) {
     })
   }, [])
 
-  const addSpecialRequest = useCallback((text: string) => {
-    setCart((prev) => ({
-      ...prev,
-      specialRequests: [
-        ...prev.specialRequests,
-        { id: crypto.randomUUID(), text },
-      ],
-    }))
+  const addSpecialRequest = useCallback((itemId: number, text: string) => {
+    setCart((prev) => {
+      const existing = prev.lines[itemId]
+      if (!existing) return prev
+      return {
+        ...prev,
+        lines: {
+          ...prev.lines,
+          [itemId]: {
+            ...existing,
+            specialRequests: [...existing.specialRequests, text],
+          },
+        },
+      }
+    })
   }, [])
 
-  const removeSpecialRequest = useCallback((id: string) => {
-    setCart((prev) => ({
-      ...prev,
-      specialRequests: prev.specialRequests.filter((sr) => sr.id !== id),
-    }))
+  const removeSpecialRequest = useCallback((itemId: number, index: number) => {
+    setCart((prev) => {
+      const existing = prev.lines[itemId]
+      if (!existing) return prev
+      return {
+        ...prev,
+        lines: {
+          ...prev.lines,
+          [itemId]: {
+            ...existing,
+            specialRequests: existing.specialRequests.filter((_, i) => i !== index),
+          },
+        },
+      }
+    })
   }, [])
 
   const toggleExtra = useCallback((itemId: number) => {
@@ -225,7 +236,6 @@ export function CartProvider({ children }: { children: ReactNode }) {
   const value: CartContextValue = {
     tableId: cart.tableId,
     lines: cart.lines,
-    specialRequests: cart.specialRequests,
     count,
     total,
     regularCount,

--- a/apps/waiter-web/src/contexts/CartContext.tsx
+++ b/apps/waiter-web/src/contexts/CartContext.tsx
@@ -12,10 +12,15 @@ import type { MenuItemDto } from '@serva/shared-types'
 // Types
 // ---------------------------------------------------------------------------
 
+export interface SpecialRequest {
+  text: string
+  qty: number
+}
+
 export interface CartLine {
   item: MenuItemDto
   qty: number
-  specialRequests: string[]
+  specialRequests: SpecialRequest[]
   /** When true this line is submitted as a separate "extra" order so the
    *  kitchen receives it distinctly from the main order. */
   isExtra: boolean
@@ -64,6 +69,7 @@ interface CartContextValue {
   // ── Per-item special requests ───────────────────────────────────────────
   addSpecialRequest(itemId: number, text: string): void
   removeSpecialRequest(itemId: number, index: number): void
+  setSpecialRequestQty(itemId: number, index: number, qty: number): void
 
   // ── Payment tracking ────────────────────────────────────────────────────
   /**
@@ -169,7 +175,7 @@ export function CartProvider({ children }: { children: ReactNode }) {
           ...prev.lines,
           [itemId]: {
             ...existing,
-            specialRequests: [...existing.specialRequests, text],
+            specialRequests: [...existing.specialRequests, { text, qty: 1 }],
           },
         },
       }
@@ -189,6 +195,32 @@ export function CartProvider({ children }: { children: ReactNode }) {
             specialRequests: existing.specialRequests.filter((_, i) => i !== index),
           },
         },
+      }
+    })
+  }, [])
+
+  const setSpecialRequestQty = useCallback((itemId: number, index: number, qty: number) => {
+    setCart((prev) => {
+      const existing = prev.lines[itemId]
+      if (!existing) return prev
+      if (qty <= 0) {
+        return {
+          ...prev,
+          lines: {
+            ...prev.lines,
+            [itemId]: {
+              ...existing,
+              specialRequests: existing.specialRequests.filter((_, i) => i !== index),
+            },
+          },
+        }
+      }
+      const updated = existing.specialRequests.map((sr, i) =>
+        i === index ? { ...sr, qty } : sr,
+      )
+      return {
+        ...prev,
+        lines: { ...prev.lines, [itemId]: { ...existing, specialRequests: updated } },
       }
     })
   }, [])
@@ -249,6 +281,7 @@ export function CartProvider({ children }: { children: ReactNode }) {
     toggleExtra,
     addSpecialRequest,
     removeSpecialRequest,
+    setSpecialRequestQty,
     payItems,
   }
 

--- a/apps/waiter-web/src/contexts/CartContext.tsx
+++ b/apps/waiter-web/src/contexts/CartContext.tsx
@@ -67,7 +67,7 @@ interface CartContextValue {
   toggleExtra(itemId: number): void
 
   // ── Per-item special requests ───────────────────────────────────────────
-  addSpecialRequest(itemId: number, text: string): void
+  addSpecialRequest(item: MenuItemDto, text: string): void
   removeSpecialRequest(itemId: number, index: number): void
   setSpecialRequestQty(itemId: number, index: number, qty: number): void
 
@@ -135,6 +135,9 @@ export function CartProvider({ children }: { children: ReactNode }) {
       const existing = prev.lines[itemId]
       if (!existing) return prev
       if (existing.qty <= 1) {
+        if (existing.specialRequests.length > 0) {
+          return { ...prev, lines: { ...prev.lines, [itemId]: { ...existing, qty: 0 } } }
+        }
         const { [itemId]: _l, ...restLines } = prev.lines
         return { ...prev, lines: restLines }
       }
@@ -158,6 +161,9 @@ export function CartProvider({ children }: { children: ReactNode }) {
       const existing = prev.lines[itemId]
       if (!existing) return prev
       if (qty <= 0) {
+        if (existing.specialRequests.length > 0) {
+          return { ...prev, lines: { ...prev.lines, [itemId]: { ...existing, qty: 0 } } }
+        }
         const { [itemId]: _l, ...restLines } = prev.lines
         return { ...prev, lines: restLines }
       }
@@ -165,17 +171,23 @@ export function CartProvider({ children }: { children: ReactNode }) {
     })
   }, [])
 
-  const addSpecialRequest = useCallback((itemId: number, text: string) => {
+  const addSpecialRequest = useCallback((item: MenuItemDto, text: string) => {
     setCart((prev) => {
-      const existing = prev.lines[itemId]
-      if (!existing) return prev
+      const existing = prev.lines[item.id]
+      const base: CartLine = existing ?? {
+        item,
+        qty: 0,
+        specialRequests: [],
+        isExtra: false,
+        paidQty: 0,
+      }
       return {
         ...prev,
         lines: {
           ...prev.lines,
-          [itemId]: {
-            ...existing,
-            specialRequests: [...existing.specialRequests, { text, qty: 1 }],
+          [item.id]: {
+            ...base,
+            specialRequests: [...base.specialRequests, { text, qty: 1 }],
           },
         },
       }
@@ -186,14 +198,16 @@ export function CartProvider({ children }: { children: ReactNode }) {
     setCart((prev) => {
       const existing = prev.lines[itemId]
       if (!existing) return prev
+      const remaining = existing.specialRequests.filter((_, i) => i !== index)
+      if (remaining.length === 0 && existing.qty <= 0) {
+        const { [itemId]: _l, ...restLines } = prev.lines
+        return { ...prev, lines: restLines }
+      }
       return {
         ...prev,
         lines: {
           ...prev.lines,
-          [itemId]: {
-            ...existing,
-            specialRequests: existing.specialRequests.filter((_, i) => i !== index),
-          },
+          [itemId]: { ...existing, specialRequests: remaining },
         },
       }
     })
@@ -204,14 +218,16 @@ export function CartProvider({ children }: { children: ReactNode }) {
       const existing = prev.lines[itemId]
       if (!existing) return prev
       if (qty <= 0) {
+        const remaining = existing.specialRequests.filter((_, i) => i !== index)
+        if (remaining.length === 0 && existing.qty <= 0) {
+          const { [itemId]: _l, ...restLines } = prev.lines
+          return { ...prev, lines: restLines }
+        }
         return {
           ...prev,
           lines: {
             ...prev.lines,
-            [itemId]: {
-              ...existing,
-              specialRequests: existing.specialRequests.filter((_, i) => i !== index),
-            },
+            [itemId]: { ...existing, specialRequests: remaining },
           },
         }
       }

--- a/apps/waiter-web/src/contexts/CartContext.tsx
+++ b/apps/waiter-web/src/contexts/CartContext.tsx
@@ -12,10 +12,14 @@ import type { MenuItemDto } from '@serva/shared-types'
 // Types
 // ---------------------------------------------------------------------------
 
+export interface SpecialRequest {
+  id: string
+  text: string
+}
+
 export interface CartLine {
   item: MenuItemDto
   qty: number
-  specialRequests: string
   /** When true this line is submitted as a separate "extra" order so the
    *  kitchen receives it distinctly from the main order. */
   isExtra: boolean
@@ -26,11 +30,13 @@ export interface CartLine {
 interface CartState {
   tableId: number | null
   lines: Record<number, CartLine>
+  specialRequests: SpecialRequest[]
 }
 
 interface CartContextValue {
   tableId: number | null
   lines: Record<number, CartLine>
+  specialRequests: SpecialRequest[]
   /** Total item count across all lines (sum of quantities). */
   count: number
   /** Grand total in currency units. */
@@ -58,9 +64,12 @@ interface CartContextValue {
   removeItem(itemId: number): void
   /** Sets qty directly; removes line at qty <= 0. */
   setQuantity(itemId: number, qty: number): void
-  setSpecialRequests(itemId: number, text: string): void
   /** Toggles the isExtra flag. */
   toggleExtra(itemId: number): void
+
+  // ── Special requests ────────────────────────────────────────────────────
+  addSpecialRequest(text: string): void
+  removeSpecialRequest(id: string): void
 
   // ── Payment tracking ────────────────────────────────────────────────────
   /**
@@ -84,6 +93,7 @@ const CartContext = createContext<CartContextValue | null>(null)
 const EMPTY_CART: CartState = {
   tableId: null,
   lines: {},
+  specialRequests: [],
 }
 
 export function CartProvider({ children }: { children: ReactNode }) {
@@ -112,7 +122,6 @@ export function CartProvider({ children }: { children: ReactNode }) {
           [item.id]: {
             item,
             qty: (existing?.qty ?? 0) + 1,
-            specialRequests: existing?.specialRequests ?? '',
             isExtra: existing?.isExtra ?? false,
             paidQty: existing?.paidQty ?? 0,
           },
@@ -156,15 +165,21 @@ export function CartProvider({ children }: { children: ReactNode }) {
     })
   }, [])
 
-  const setSpecialRequests = useCallback((itemId: number, text: string) => {
-    setCart((prev) => {
-      const existing = prev.lines[itemId]
-      if (!existing) return prev
-      return {
-        ...prev,
-        lines: { ...prev.lines, [itemId]: { ...existing, specialRequests: text } },
-      }
-    })
+  const addSpecialRequest = useCallback((text: string) => {
+    setCart((prev) => ({
+      ...prev,
+      specialRequests: [
+        ...prev.specialRequests,
+        { id: crypto.randomUUID(), text },
+      ],
+    }))
+  }, [])
+
+  const removeSpecialRequest = useCallback((id: string) => {
+    setCart((prev) => ({
+      ...prev,
+      specialRequests: prev.specialRequests.filter((sr) => sr.id !== id),
+    }))
   }, [])
 
   const toggleExtra = useCallback((itemId: number) => {
@@ -210,6 +225,7 @@ export function CartProvider({ children }: { children: ReactNode }) {
   const value: CartContextValue = {
     tableId: cart.tableId,
     lines: cart.lines,
+    specialRequests: cart.specialRequests,
     count,
     total,
     regularCount,
@@ -220,8 +236,9 @@ export function CartProvider({ children }: { children: ReactNode }) {
     decrementItem,
     removeItem,
     setQuantity,
-    setSpecialRequests,
     toggleExtra,
+    addSpecialRequest,
+    removeSpecialRequest,
     payItems,
   }
 

--- a/apps/waiter-web/src/index.css
+++ b/apps/waiter-web/src/index.css
@@ -2541,6 +2541,32 @@ body {
   color: var(--color-text);
 }
 
+.sr-box__add {
+  flex-shrink: 0;
+  border: 1.5px solid var(--color-accent);
+  border-radius: 999px;
+  background: none;
+  color: var(--color-accent);
+  font: inherit;
+  font-size: 13px;
+  font-weight: 600;
+  padding: 5px 14px;
+  cursor: pointer;
+  -webkit-tap-highlight-color: transparent;
+  touch-action: manipulation;
+  transition: background 0.12s;
+}
+
+.sr-box__add:active {
+  background: color-mix(in srgb, var(--color-accent) 10%, transparent);
+}
+
+@media (hover: hover) {
+  .sr-box__add:hover {
+    background: color-mix(in srgb, var(--color-accent) 8%, transparent);
+  }
+}
+
 .sr-box__stepper {
   flex-shrink: 0;
 }
@@ -2557,7 +2583,7 @@ body {
 .sr-box__entry {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: 10px;
   padding: 8px 10px;
   background: var(--color-bg);
   border: 1px solid var(--color-border);
@@ -2569,28 +2595,6 @@ body {
   min-width: 0;
   font-size: 14px;
   color: var(--color-text);
-}
-
-.sr-box__remove {
-  flex-shrink: 0;
-  width: 28px;
-  height: 28px;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  border: none;
-  border-radius: 999px;
-  background: transparent;
-  color: var(--color-text-muted);
-  font-size: 18px;
-  line-height: 1;
-  cursor: pointer;
-  -webkit-tap-highlight-color: transparent;
-  touch-action: manipulation;
-}
-
-.sr-box__remove:not(:disabled):active {
-  color: var(--color-danger);
 }
 
 /* ─── Per-item special requests list (OrderPage) ────────────── */
@@ -2606,7 +2610,7 @@ body {
 .sr-list__item {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: 10px;
   padding: 6px 10px;
   background: color-mix(in srgb, var(--color-accent) 6%, var(--color-surface));
   border: 1px solid color-mix(in srgb, var(--color-accent) 20%, var(--color-border));
@@ -2620,31 +2624,8 @@ body {
   color: var(--color-text);
 }
 
-.sr-list__remove {
+.sr-list__stepper {
   flex-shrink: 0;
-  width: 24px;
-  height: 24px;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  border: none;
-  border-radius: 999px;
-  background: transparent;
-  color: var(--color-text-muted);
-  font-size: 16px;
-  line-height: 1;
-  cursor: pointer;
-  -webkit-tap-highlight-color: transparent;
-  touch-action: manipulation;
-}
-
-.sr-list__remove:disabled {
-  opacity: 0.4;
-  cursor: not-allowed;
-}
-
-.sr-list__remove:not(:disabled):active {
-  color: var(--color-danger);
 }
 
 /* ─── Special request dialog ────────────────────────────────── */

--- a/apps/waiter-web/src/index.css
+++ b/apps/waiter-web/src/index.css
@@ -607,8 +607,8 @@ body {
 
 .menu-row {
   display: flex;
-  align-items: center;
-  gap: 12px;
+  flex-direction: column;
+  gap: 8px;
   padding: 12px 14px;
   border: 1px solid var(--color-border);
   border-radius: var(--radius);
@@ -2512,89 +2512,61 @@ body {
   gap: 12px;
 }
 
-/* ─── Per-item special request box (MenuPage) ───────────────── */
-.sr-box {
-  border: 1.5px solid color-mix(in srgb, var(--color-accent) 25%, var(--color-border));
-  border-radius: 10px;
-  background: color-mix(in srgb, var(--color-accent) 4%, var(--color-bg));
-  overflow: hidden;
-}
-
-.sr-box__header {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  padding: 10px 12px;
-}
-
-.sr-box__icon {
-  width: 18px;
-  height: 18px;
-  flex-shrink: 0;
-  color: var(--color-accent);
-}
-
-.sr-box__label {
-  flex: 1;
-  font-size: 14px;
-  font-weight: 600;
-  color: var(--color-text);
-}
-
-.sr-box__add {
-  flex-shrink: 0;
-  border: 1.5px solid var(--color-accent);
-  border-radius: 999px;
+/* ─── Special request add button (MenuPage) ──────────────────── */
+.sr-add-btn {
+  align-self: flex-start;
+  border: 1.5px dashed var(--color-accent);
+  border-radius: var(--radius);
   background: none;
   color: var(--color-accent);
   font: inherit;
-  font-size: 13px;
+  font-size: 14px;
   font-weight: 600;
-  padding: 5px 14px;
+  padding: 8px 16px;
   cursor: pointer;
   -webkit-tap-highlight-color: transparent;
   touch-action: manipulation;
   transition: background 0.12s;
 }
 
-.sr-box__add:active {
+.sr-add-btn:active {
   background: color-mix(in srgb, var(--color-accent) 10%, transparent);
 }
 
 @media (hover: hover) {
-  .sr-box__add:hover {
+  .sr-add-btn:hover {
     background: color-mix(in srgb, var(--color-accent) 8%, transparent);
   }
 }
 
-.sr-box__stepper {
-  flex-shrink: 0;
-}
-
-.sr-box__list {
+/* ─── Special request items list (MenuPage) ──────────────────── */
+.sr-item-list {
   list-style: none;
-  padding: 0 12px 10px;
+  padding: 0;
   margin: 0;
   display: flex;
   flex-direction: column;
   gap: 6px;
 }
 
-.sr-box__entry {
+.sr-item-row {
   display: flex;
   align-items: center;
-  gap: 10px;
-  padding: 8px 10px;
-  background: var(--color-bg);
+  gap: 12px;
+  padding: 10px 12px;
   border: 1px solid var(--color-border);
-  border-radius: 8px;
+  border-radius: var(--radius);
+  background: var(--color-surface);
 }
 
-.sr-box__text {
+.sr-item-row__name {
   flex: 1;
   min-width: 0;
-  font-size: 14px;
-  color: var(--color-text);
+  font-size: 16px;
+  font-weight: 600;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 /* ─── Per-item special requests list (OrderPage) ────────────── */

--- a/apps/waiter-web/src/index.css
+++ b/apps/waiter-web/src/index.css
@@ -2504,3 +2504,274 @@ body {
   display: flex;
   justify-content: flex-end;
 }
+
+/* ─── Special request button (MenuPage) ─────────────────────── */
+.special-request-btn {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  padding: 12px 16px;
+  border: 1.5px dashed var(--color-border);
+  border-radius: var(--radius);
+  background: var(--color-surface);
+  color: var(--color-text);
+  font: inherit;
+  font-size: 15px;
+  font-weight: 500;
+  cursor: pointer;
+  -webkit-tap-highlight-color: transparent;
+  touch-action: manipulation;
+  transition: border-color 0.12s, background 0.12s;
+}
+
+.special-request-btn:active {
+  background: color-mix(in srgb, var(--color-accent) 6%, var(--color-surface));
+  border-color: var(--color-accent);
+}
+
+@media (hover: hover) {
+  .special-request-btn:hover {
+    border-color: var(--color-accent);
+    background: color-mix(in srgb, var(--color-accent) 4%, var(--color-surface));
+  }
+}
+
+.special-request-btn__icon {
+  width: 22px;
+  height: 22px;
+  flex-shrink: 0;
+  color: var(--color-accent);
+}
+
+.special-request-btn__label {
+  flex: 1;
+  text-align: left;
+}
+
+.special-request-btn__badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 22px;
+  height: 22px;
+  padding: 0 6px;
+  border-radius: 99px;
+  background: var(--color-accent);
+  color: var(--color-accent-fg);
+  font-size: 12px;
+  font-weight: 700;
+  line-height: 1;
+}
+
+/* ─── Special requests list (MenuPage) ──────────────────────── */
+.sr-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.sr-list__item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 12px;
+  background: color-mix(in srgb, var(--color-accent) 6%, var(--color-surface));
+  border: 1px solid color-mix(in srgb, var(--color-accent) 20%, var(--color-border));
+  border-radius: var(--radius);
+}
+
+.sr-list__text {
+  flex: 1;
+  min-width: 0;
+  font-size: 14px;
+  color: var(--color-text);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.sr-list__remove {
+  flex-shrink: 0;
+  width: 28px;
+  height: 28px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  border-radius: 999px;
+  background: transparent;
+  color: var(--color-text-muted);
+  font-size: 18px;
+  line-height: 1;
+  cursor: pointer;
+  -webkit-tap-highlight-color: transparent;
+  touch-action: manipulation;
+}
+
+.sr-list__remove:active {
+  color: var(--color-danger);
+}
+
+/* ─── Special request dialog ────────────────────────────────── */
+.sr-dialog-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 60;
+  background: rgba(0, 0, 0, 0.6);
+  display: flex;
+  align-items: flex-end;
+  justify-content: center;
+  padding: 16px;
+}
+
+.sr-dialog {
+  width: 100%;
+  max-width: 460px;
+  background: var(--color-bg);
+  border-radius: var(--radius);
+  border: 1px solid var(--color-border);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  animation: sr-dialog-in 0.18s ease;
+}
+
+@keyframes sr-dialog-in {
+  from { opacity: 0; transform: translateY(24px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+.sr-dialog__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.sr-dialog__header h3 {
+  font-size: 17px;
+  font-weight: 600;
+}
+
+.sr-dialog__close {
+  background: none;
+  border: none;
+  color: var(--color-text);
+  font-size: 24px;
+  line-height: 1;
+  cursor: pointer;
+  padding: 4px 8px;
+}
+
+.sr-dialog__body {
+  padding: 16px;
+}
+
+.sr-dialog__input {
+  width: 100%;
+  padding: 10px 12px;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius);
+  background: var(--color-surface);
+  color: var(--color-text);
+  font: inherit;
+  font-size: 16px;
+  line-height: 1.4;
+  resize: none;
+  outline: none;
+}
+
+.sr-dialog__input:focus {
+  border-color: var(--color-accent);
+}
+
+.sr-dialog__footer {
+  padding: 0 16px 16px;
+}
+
+.sr-dialog__add {
+  border-radius: 10px;
+}
+
+/* ─── Special requests section (OrderPage) ──────────────────── */
+.order-special-requests {
+  border: 1.5px solid color-mix(in srgb, var(--color-accent) 30%, var(--color-border));
+  border-radius: var(--radius);
+  background: color-mix(in srgb, var(--color-accent) 4%, var(--color-surface));
+  overflow: hidden;
+}
+
+.order-special-requests__header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 14px;
+  font-size: 13px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--color-accent);
+  border-bottom: 1px solid color-mix(in srgb, var(--color-accent) 15%, var(--color-border));
+}
+
+.order-special-requests__icon {
+  flex-shrink: 0;
+}
+
+.order-special-requests__list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.order-special-requests__item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 14px;
+  border-bottom: 1px solid color-mix(in srgb, var(--color-accent) 10%, var(--color-border));
+}
+
+.order-special-requests__item:last-child {
+  border-bottom: none;
+}
+
+.order-special-requests__text {
+  flex: 1;
+  min-width: 0;
+  font-size: 14px;
+  color: var(--color-text);
+}
+
+.order-special-requests__remove {
+  flex-shrink: 0;
+  width: 32px;
+  height: 32px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--color-border);
+  border-radius: 999px;
+  background: var(--color-bg);
+  color: var(--color-text-muted);
+  font-size: 18px;
+  line-height: 1;
+  cursor: pointer;
+  -webkit-tap-highlight-color: transparent;
+  touch-action: manipulation;
+}
+
+.order-special-requests__remove:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.order-special-requests__remove:not(:disabled):active {
+  color: var(--color-danger);
+  border-color: var(--color-danger);
+}

--- a/apps/waiter-web/src/index.css
+++ b/apps/waiter-web/src/index.css
@@ -2505,99 +2505,100 @@ body {
   justify-content: flex-end;
 }
 
-/* ─── Special request button (MenuPage) ─────────────────────── */
-.special-request-btn {
+/* ─── Per-item special request button (MenuPage) ───────────── */
+.menu-row__actions {
   display: flex;
   align-items: center;
-  gap: 10px;
-  width: 100%;
-  padding: 12px 16px;
-  border: 1.5px dashed var(--color-border);
-  border-radius: var(--radius);
-  background: var(--color-surface);
-  color: var(--color-text);
-  font: inherit;
-  font-size: 15px;
-  font-weight: 500;
-  cursor: pointer;
-  -webkit-tap-highlight-color: transparent;
-  touch-action: manipulation;
-  transition: border-color 0.12s, background 0.12s;
-}
-
-.special-request-btn:active {
-  background: color-mix(in srgb, var(--color-accent) 6%, var(--color-surface));
-  border-color: var(--color-accent);
-}
-
-@media (hover: hover) {
-  .special-request-btn:hover {
-    border-color: var(--color-accent);
-    background: color-mix(in srgb, var(--color-accent) 4%, var(--color-surface));
-  }
-}
-
-.special-request-btn__icon {
-  width: 22px;
-  height: 22px;
+  gap: 8px;
   flex-shrink: 0;
-  color: var(--color-accent);
 }
 
-.special-request-btn__label {
-  flex: 1;
-  text-align: left;
-}
-
-.special-request-btn__badge {
+.menu-row__sr-btn {
+  position: relative;
+  width: 40px;
+  height: 40px;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  min-width: 22px;
-  height: 22px;
-  padding: 0 6px;
+  border: 1px solid var(--color-border);
+  border-radius: 999px;
+  background: var(--color-bg);
+  color: var(--color-text-muted);
+  cursor: pointer;
+  -webkit-tap-highlight-color: transparent;
+  touch-action: manipulation;
+  transition: border-color 0.12s, color 0.12s;
+}
+
+.menu-row__sr-btn--has {
+  border-color: var(--color-accent);
+  color: var(--color-accent);
+}
+
+@media (hover: hover) {
+  .menu-row__sr-btn:hover {
+    border-color: var(--color-accent);
+    color: var(--color-accent);
+  }
+}
+
+.menu-row__sr-btn:active {
+  transform: scale(0.92);
+}
+
+.menu-row__sr-badge {
+  position: absolute;
+  top: -4px;
+  right: -4px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 18px;
+  height: 18px;
+  padding: 0 4px;
   border-radius: 99px;
   background: var(--color-accent);
   color: var(--color-accent-fg);
-  font-size: 12px;
+  font-size: 11px;
   font-weight: 700;
   line-height: 1;
 }
 
-/* ─── Special requests list (MenuPage) ──────────────────────── */
+/* ─── Per-item special requests list (shared) ───────────────── */
 .sr-list {
   list-style: none;
   padding: 0;
-  margin: 0;
+  margin: 4px 0 0;
   display: flex;
   flex-direction: column;
-  gap: 6px;
+  gap: 4px;
+}
+
+.sr-list--order {
+  margin-top: 0;
 }
 
 .sr-list__item {
   display: flex;
   align-items: center;
-  gap: 10px;
-  padding: 8px 12px;
+  gap: 8px;
+  padding: 5px 10px;
   background: color-mix(in srgb, var(--color-accent) 6%, var(--color-surface));
   border: 1px solid color-mix(in srgb, var(--color-accent) 20%, var(--color-border));
-  border-radius: var(--radius);
+  border-radius: 6px;
+  font-size: 13px;
 }
 
 .sr-list__text {
   flex: 1;
   min-width: 0;
-  font-size: 14px;
   color: var(--color-text);
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
 }
 
 .sr-list__remove {
   flex-shrink: 0;
-  width: 28px;
-  height: 28px;
+  width: 24px;
+  height: 24px;
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -2605,14 +2606,19 @@ body {
   border-radius: 999px;
   background: transparent;
   color: var(--color-text-muted);
-  font-size: 18px;
+  font-size: 16px;
   line-height: 1;
   cursor: pointer;
   -webkit-tap-highlight-color: transparent;
   touch-action: manipulation;
 }
 
-.sr-list__remove:active {
+.sr-list__remove:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.sr-list__remove:not(:disabled):active {
   color: var(--color-danger);
 }
 
@@ -2648,7 +2654,7 @@ body {
 .sr-dialog__header {
   display: flex;
   align-items: center;
-  justify-content: space-between;
+  gap: 8px;
   padding: 12px 16px;
   border-bottom: 1px solid var(--color-border);
 }
@@ -2658,7 +2664,17 @@ body {
   font-weight: 600;
 }
 
+.sr-dialog__item-name {
+  flex: 1;
+  font-size: 14px;
+  color: var(--color-text-muted);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .sr-dialog__close {
+  flex-shrink: 0;
   background: none;
   border: none;
   color: var(--color-text);
@@ -2696,82 +2712,4 @@ body {
 
 .sr-dialog__add {
   border-radius: 10px;
-}
-
-/* ─── Special requests section (OrderPage) ──────────────────── */
-.order-special-requests {
-  border: 1.5px solid color-mix(in srgb, var(--color-accent) 30%, var(--color-border));
-  border-radius: var(--radius);
-  background: color-mix(in srgb, var(--color-accent) 4%, var(--color-surface));
-  overflow: hidden;
-}
-
-.order-special-requests__header {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  padding: 10px 14px;
-  font-size: 13px;
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-  color: var(--color-accent);
-  border-bottom: 1px solid color-mix(in srgb, var(--color-accent) 15%, var(--color-border));
-}
-
-.order-special-requests__icon {
-  flex-shrink: 0;
-}
-
-.order-special-requests__list {
-  list-style: none;
-  padding: 0;
-  margin: 0;
-}
-
-.order-special-requests__item {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  padding: 10px 14px;
-  border-bottom: 1px solid color-mix(in srgb, var(--color-accent) 10%, var(--color-border));
-}
-
-.order-special-requests__item:last-child {
-  border-bottom: none;
-}
-
-.order-special-requests__text {
-  flex: 1;
-  min-width: 0;
-  font-size: 14px;
-  color: var(--color-text);
-}
-
-.order-special-requests__remove {
-  flex-shrink: 0;
-  width: 32px;
-  height: 32px;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  border: 1px solid var(--color-border);
-  border-radius: 999px;
-  background: var(--color-bg);
-  color: var(--color-text-muted);
-  font-size: 18px;
-  line-height: 1;
-  cursor: pointer;
-  -webkit-tap-highlight-color: transparent;
-  touch-action: manipulation;
-}
-
-.order-special-requests__remove:disabled {
-  opacity: 0.4;
-  cursor: not-allowed;
-}
-
-.order-special-requests__remove:not(:disabled):active {
-  color: var(--color-danger);
-  border-color: var(--color-danger);
 }

--- a/apps/waiter-web/src/index.css
+++ b/apps/waiter-web/src/index.css
@@ -2505,84 +2505,109 @@ body {
   justify-content: flex-end;
 }
 
-/* ─── Per-item special request button (MenuPage) ───────────── */
-.menu-row__actions {
+/* ─── Menu row top (info + qty stepper side by side) ────────── */
+.menu-row__top {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+/* ─── Per-item special request box (MenuPage) ───────────────── */
+.sr-box {
+  border: 1.5px solid color-mix(in srgb, var(--color-accent) 25%, var(--color-border));
+  border-radius: 10px;
+  background: color-mix(in srgb, var(--color-accent) 4%, var(--color-bg));
+  overflow: hidden;
+}
+
+.sr-box__header {
   display: flex;
   align-items: center;
   gap: 8px;
+  padding: 10px 12px;
+}
+
+.sr-box__icon {
+  width: 18px;
+  height: 18px;
   flex-shrink: 0;
-}
-
-.menu-row__sr-btn {
-  position: relative;
-  width: 40px;
-  height: 40px;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  border: 1px solid var(--color-border);
-  border-radius: 999px;
-  background: var(--color-bg);
-  color: var(--color-text-muted);
-  cursor: pointer;
-  -webkit-tap-highlight-color: transparent;
-  touch-action: manipulation;
-  transition: border-color 0.12s, color 0.12s;
-}
-
-.menu-row__sr-btn--has {
-  border-color: var(--color-accent);
   color: var(--color-accent);
 }
 
-@media (hover: hover) {
-  .menu-row__sr-btn:hover {
-    border-color: var(--color-accent);
-    color: var(--color-accent);
-  }
+.sr-box__label {
+  flex: 1;
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--color-text);
 }
 
-.menu-row__sr-btn:active {
-  transform: scale(0.92);
+.sr-box__stepper {
+  flex-shrink: 0;
 }
 
-.menu-row__sr-badge {
-  position: absolute;
-  top: -4px;
-  right: -4px;
+.sr-box__list {
+  list-style: none;
+  padding: 0 12px 10px;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.sr-box__entry {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 10px;
+  background: var(--color-bg);
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+}
+
+.sr-box__text {
+  flex: 1;
+  min-width: 0;
+  font-size: 14px;
+  color: var(--color-text);
+}
+
+.sr-box__remove {
+  flex-shrink: 0;
+  width: 28px;
+  height: 28px;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  min-width: 18px;
-  height: 18px;
-  padding: 0 4px;
-  border-radius: 99px;
-  background: var(--color-accent);
-  color: var(--color-accent-fg);
-  font-size: 11px;
-  font-weight: 700;
+  border: none;
+  border-radius: 999px;
+  background: transparent;
+  color: var(--color-text-muted);
+  font-size: 18px;
   line-height: 1;
+  cursor: pointer;
+  -webkit-tap-highlight-color: transparent;
+  touch-action: manipulation;
 }
 
-/* ─── Per-item special requests list (shared) ───────────────── */
+.sr-box__remove:not(:disabled):active {
+  color: var(--color-danger);
+}
+
+/* ─── Per-item special requests list (OrderPage) ────────────── */
 .sr-list {
   list-style: none;
   padding: 0;
-  margin: 4px 0 0;
+  margin: 0;
   display: flex;
   flex-direction: column;
   gap: 4px;
-}
-
-.sr-list--order {
-  margin-top: 0;
 }
 
 .sr-list__item {
   display: flex;
   align-items: center;
   gap: 8px;
-  padding: 5px 10px;
+  padding: 6px 10px;
   background: color-mix(in srgb, var(--color-accent) 6%, var(--color-surface));
   border: 1px solid color-mix(in srgb, var(--color-accent) 20%, var(--color-border));
   border-radius: 6px;

--- a/apps/waiter-web/src/pages/MenuPage.tsx
+++ b/apps/waiter-web/src/pages/MenuPage.tsx
@@ -46,7 +46,7 @@ export function MenuPage() {
   } = useCart()
 
   // Track which item's special-request dialog is open (null = none).
-  const [srDialogItemId, setSrDialogItemId] = useState<number | null>(null)
+  const [srDialogItem, setSrDialogItem] = useState<MenuItemDto | null>(null)
 
   // Prefer a name passed via navigation state (the common path from TablesPage).
   // Fall back to a tables.list() lookup if the user landed on this URL directly
@@ -207,14 +207,14 @@ export function MenuPage() {
         onRetry={loadCategories}
       />
 
-      {srDialogItemId != null && (
+      {srDialogItem != null && (
         <SpecialRequestDialog
-          itemName={lines[srDialogItemId]?.item.name ?? ''}
+          itemName={srDialogItem.name}
           onAdd={(text) => {
-            addSpecialRequest(srDialogItemId, text)
-            setSrDialogItemId(null)
+            addSpecialRequest(srDialogItem, text)
+            setSrDialogItem(null)
           }}
-          onClose={() => setSrDialogItemId(null)}
+          onClose={() => setSrDialogItem(null)}
         />
       )}
 
@@ -224,14 +224,14 @@ export function MenuPage() {
         cart={lines}
         onAdd={addToCart}
         onRemove={removeFromCart}
-        onOpenSpecialRequest={(itemId) => setSrDialogItemId(itemId)}
+        onOpenSpecialRequest={(item) => setSrDialogItem(item)}
         onSetSpecialRequestQty={setSpecialRequestQty}
         onRetry={() => {
           if (activeCategoryId != null) loadItems(activeCategoryId)
         }}
       />
 
-      {count > 0 && (
+      {(count > 0 || Object.values(lines).some((l) => l.specialRequests.length > 0)) && (
         <button
           type="button"
           className="next-cta"
@@ -347,7 +347,7 @@ interface ItemsListProps {
   cart: Record<number, CartLine>
   onAdd: (item: MenuItemDto) => void
   onRemove: (item: MenuItemDto) => void
-  onOpenSpecialRequest: (itemId: number) => void
+  onOpenSpecialRequest: (item: MenuItemDto) => void
   onSetSpecialRequestQty: (itemId: number, index: number, qty: number) => void
   onRetry: () => void
 }
@@ -486,7 +486,7 @@ function ItemsList({
       {state.items.map((item) => {
         const line = cart[item.id]
         const qty = line?.qty ?? 0
-        const inCart = qty > 0
+        const inCart = qty > 0 || (line?.specialRequests.length ?? 0) > 0
         const srs = line?.specialRequests ?? []
         return (
           <li
@@ -530,59 +530,46 @@ function ItemsList({
               </div>
             </div>
 
-            {inCart && (
-              <div className="sr-box">
-                <div className="sr-box__header">
-                  <svg className="sr-box__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
-                    <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
-                    <polyline points="14 2 14 8 20 8" />
-                    <line x1="12" y1="18" x2="12" y2="12" />
-                    <line x1="9" y1="15" x2="15" y2="15" />
-                  </svg>
-                  <span className="sr-box__label">Sonderw&uuml;nsche</span>
-                  <button
-                    type="button"
-                    className="sr-box__add"
-                    onClick={() => onOpenSpecialRequest(item.id)}
-                    aria-label="Sonderwunsch hinzufügen"
-                  >
-                    + Hinzuf&uuml;gen
-                  </button>
-                </div>
+            <button
+              type="button"
+              className="sr-add-btn"
+              onClick={() => onOpenSpecialRequest(item)}
+              aria-label={`Sonderwunsch für ${item.name} hinzufügen`}
+            >
+              + Sonderwunsch
+            </button>
 
-                {srs.length > 0 && (
-                  <ul className="sr-box__list">
-                    {srs.map((sr, idx) => (
-                      <li key={idx} className="sr-box__entry">
-                        <span className="sr-box__text">{sr.text}</span>
-                        <div
-                          className="stepper sr-box__stepper"
-                          role="group"
-                          aria-label={`Anzahl: ${sr.text}`}
-                        >
-                          <button
-                            type="button"
-                            className="stepper__btn"
-                            onClick={() => onSetSpecialRequestQty(item.id, idx, sr.qty - 1)}
-                            aria-label="Eins weniger"
-                          >
-                            −
-                          </button>
-                          <span className="stepper__value">{sr.qty}</span>
-                          <button
-                            type="button"
-                            className="stepper__btn stepper__btn--add"
-                            onClick={() => onSetSpecialRequestQty(item.id, idx, sr.qty + 1)}
-                            aria-label="Eins mehr"
-                          >
-                            +
-                          </button>
-                        </div>
-                      </li>
-                    ))}
-                  </ul>
-                )}
-              </div>
+            {srs.length > 0 && (
+              <ul className="sr-item-list">
+                {srs.map((sr, idx) => (
+                  <li key={idx} className="sr-item-row">
+                    <span className="sr-item-row__name">{sr.text}</span>
+                    <div
+                      className="stepper"
+                      role="group"
+                      aria-label={`Anzahl: ${sr.text}`}
+                    >
+                      <button
+                        type="button"
+                        className="stepper__btn"
+                        onClick={() => onSetSpecialRequestQty(item.id, idx, sr.qty - 1)}
+                        aria-label="Eins weniger"
+                      >
+                        −
+                      </button>
+                      <span className="stepper__value">{sr.qty}</span>
+                      <button
+                        type="button"
+                        className="stepper__btn stepper__btn--add"
+                        onClick={() => onSetSpecialRequestQty(item.id, idx, sr.qty + 1)}
+                        aria-label="Eins mehr"
+                      >
+                        +
+                      </button>
+                    </div>
+                  </li>
+                ))}
+              </ul>
             )}
           </li>
         )

--- a/apps/waiter-web/src/pages/MenuPage.tsx
+++ b/apps/waiter-web/src/pages/MenuPage.tsx
@@ -493,34 +493,14 @@ function ItemsList({
             key={item.id}
             className={`menu-row${inCart ? ' menu-row--in-cart' : ''}`}
           >
-            <div className="menu-row__main">
-              <span className="menu-row__name">{item.name}</span>
-              {item.description && (
-                <span className="menu-row__description">{item.description}</span>
-              )}
-              <span className="menu-row__price">{formatPrice(item.price)}</span>
-            </div>
-
-            <div className="menu-row__actions">
-              <button
-                type="button"
-                className={`menu-row__sr-btn${srs.length > 0 ? ' menu-row__sr-btn--has' : ''}`}
-                onClick={() => {
-                  if (!inCart) onAdd(item)
-                  onOpenSpecialRequest(item.id)
-                }}
-                aria-label={`Sonderwunsch für ${item.name}`}
-              >
-                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" width="20" height="20" aria-hidden="true">
-                  <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
-                  <polyline points="14 2 14 8 20 8" />
-                  <line x1="12" y1="18" x2="12" y2="12" />
-                  <line x1="9" y1="15" x2="15" y2="15" />
-                </svg>
-                {srs.length > 0 && (
-                  <span className="menu-row__sr-badge">{srs.length}</span>
+            <div className="menu-row__top">
+              <div className="menu-row__main">
+                <span className="menu-row__name">{item.name}</span>
+                {item.description && (
+                  <span className="menu-row__description">{item.description}</span>
                 )}
-              </button>
+                <span className="menu-row__price">{formatPrice(item.price)}</span>
+              </div>
 
               <div
                 className="stepper"
@@ -550,20 +530,58 @@ function ItemsList({
               </div>
             </div>
 
-            {srs.length > 0 && (
-              <ul className="sr-list">
-                {srs.map((text, idx) => (
-                  <li key={idx} className="sr-list__item">
-                    <span className="sr-list__text">{text}</span>
+            {inCart && (
+              <div className="sr-box">
+                <div className="sr-box__header">
+                  <svg className="sr-box__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                    <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
+                    <polyline points="14 2 14 8 20 8" />
+                    <line x1="12" y1="18" x2="12" y2="12" />
+                    <line x1="9" y1="15" x2="15" y2="15" />
+                  </svg>
+                  <span className="sr-box__label">Sonderw&uuml;nsche</span>
+                  <div
+                    className="stepper sr-box__stepper"
+                    role="group"
+                    aria-label={`Sonderwünsche ${item.name}`}
+                  >
                     <button
                       type="button"
-                      className="sr-list__remove"
-                      onClick={() => onRemoveSpecialRequest(item.id, idx)}
+                      className="stepper__btn"
+                      onClick={() => onRemoveSpecialRequest(item.id, srs.length - 1)}
+                      disabled={srs.length === 0}
                       aria-label="Sonderwunsch entfernen"
-                    >&times;</button>
-                  </li>
-                ))}
-              </ul>
+                    >
+                      −
+                    </button>
+                    <span className="stepper__value">{srs.length}</span>
+                    <button
+                      type="button"
+                      className="stepper__btn stepper__btn--add"
+                      onClick={() => onOpenSpecialRequest(item.id)}
+                      aria-label="Sonderwunsch hinzufügen"
+                    >
+                      +
+                    </button>
+                  </div>
+                </div>
+
+                {srs.length > 0 && (
+                  <ul className="sr-box__list">
+                    {srs.map((text, idx) => (
+                      <li key={idx} className="sr-box__entry">
+                        <span className="sr-box__text">{text}</span>
+                        <button
+                          type="button"
+                          className="sr-box__remove"
+                          onClick={() => onRemoveSpecialRequest(item.id, idx)}
+                          aria-label="Sonderwunsch entfernen"
+                        >&times;</button>
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </div>
             )}
           </li>
         )

--- a/apps/waiter-web/src/pages/MenuPage.tsx
+++ b/apps/waiter-web/src/pages/MenuPage.tsx
@@ -42,7 +42,7 @@ export function MenuPage() {
   // Cart state lives in context so it survives navigation between menu ↔ order.
   const {
     lines, count, total, addItem, decrementItem, initForTable,
-    addSpecialRequest, removeSpecialRequest,
+    addSpecialRequest, setSpecialRequestQty,
   } = useCart()
 
   // Track which item's special-request dialog is open (null = none).
@@ -225,7 +225,7 @@ export function MenuPage() {
         onAdd={addToCart}
         onRemove={removeFromCart}
         onOpenSpecialRequest={(itemId) => setSrDialogItemId(itemId)}
-        onRemoveSpecialRequest={removeSpecialRequest}
+        onSetSpecialRequestQty={setSpecialRequestQty}
         onRetry={() => {
           if (activeCategoryId != null) loadItems(activeCategoryId)
         }}
@@ -348,7 +348,7 @@ interface ItemsListProps {
   onAdd: (item: MenuItemDto) => void
   onRemove: (item: MenuItemDto) => void
   onOpenSpecialRequest: (itemId: number) => void
-  onRemoveSpecialRequest: (itemId: number, index: number) => void
+  onSetSpecialRequestQty: (itemId: number, index: number, qty: number) => void
   onRetry: () => void
 }
 
@@ -436,7 +436,7 @@ function ItemsList({
   onAdd,
   onRemove,
   onOpenSpecialRequest,
-  onRemoveSpecialRequest,
+  onSetSpecialRequestQty,
   onRetry,
 }: ItemsListProps) {
   if (activeCategoryId == null) {
@@ -540,43 +540,44 @@ function ItemsList({
                     <line x1="9" y1="15" x2="15" y2="15" />
                   </svg>
                   <span className="sr-box__label">Sonderw&uuml;nsche</span>
-                  <div
-                    className="stepper sr-box__stepper"
-                    role="group"
-                    aria-label={`Sonderwünsche ${item.name}`}
+                  <button
+                    type="button"
+                    className="sr-box__add"
+                    onClick={() => onOpenSpecialRequest(item.id)}
+                    aria-label="Sonderwunsch hinzufügen"
                   >
-                    <button
-                      type="button"
-                      className="stepper__btn"
-                      onClick={() => onRemoveSpecialRequest(item.id, srs.length - 1)}
-                      disabled={srs.length === 0}
-                      aria-label="Sonderwunsch entfernen"
-                    >
-                      −
-                    </button>
-                    <span className="stepper__value">{srs.length}</span>
-                    <button
-                      type="button"
-                      className="stepper__btn stepper__btn--add"
-                      onClick={() => onOpenSpecialRequest(item.id)}
-                      aria-label="Sonderwunsch hinzufügen"
-                    >
-                      +
-                    </button>
-                  </div>
+                    + Hinzuf&uuml;gen
+                  </button>
                 </div>
 
                 {srs.length > 0 && (
                   <ul className="sr-box__list">
-                    {srs.map((text, idx) => (
+                    {srs.map((sr, idx) => (
                       <li key={idx} className="sr-box__entry">
-                        <span className="sr-box__text">{text}</span>
-                        <button
-                          type="button"
-                          className="sr-box__remove"
-                          onClick={() => onRemoveSpecialRequest(item.id, idx)}
-                          aria-label="Sonderwunsch entfernen"
-                        >&times;</button>
+                        <span className="sr-box__text">{sr.text}</span>
+                        <div
+                          className="stepper sr-box__stepper"
+                          role="group"
+                          aria-label={`Anzahl: ${sr.text}`}
+                        >
+                          <button
+                            type="button"
+                            className="stepper__btn"
+                            onClick={() => onSetSpecialRequestQty(item.id, idx, sr.qty - 1)}
+                            aria-label="Eins weniger"
+                          >
+                            −
+                          </button>
+                          <span className="stepper__value">{sr.qty}</span>
+                          <button
+                            type="button"
+                            className="stepper__btn stepper__btn--add"
+                            onClick={() => onSetSpecialRequestQty(item.id, idx, sr.qty + 1)}
+                            aria-label="Eins mehr"
+                          >
+                            +
+                          </button>
+                        </div>
                       </li>
                     ))}
                   </ul>

--- a/apps/waiter-web/src/pages/MenuPage.tsx
+++ b/apps/waiter-web/src/pages/MenuPage.tsx
@@ -3,7 +3,7 @@ import { useLocation, useNavigate, useParams } from 'react-router-dom'
 import type { MenuCategoryDto, MenuItemDto } from '@serva/shared-types'
 import { useApiClient } from '../hooks/useApiClient'
 import { useCart } from '../contexts/CartContext'
-import type { CartLine, SpecialRequest } from '../contexts/CartContext'
+import type { CartLine } from '../contexts/CartContext'
 
 // ---------------------------------------------------------------------------
 // Types & helpers
@@ -42,10 +42,11 @@ export function MenuPage() {
   // Cart state lives in context so it survives navigation between menu ↔ order.
   const {
     lines, count, total, addItem, decrementItem, initForTable,
-    specialRequests, addSpecialRequest, removeSpecialRequest,
+    addSpecialRequest, removeSpecialRequest,
   } = useCart()
 
-  const [showSpecialRequestDialog, setShowSpecialRequestDialog] = useState(false)
+  // Track which item's special-request dialog is open (null = none).
+  const [srDialogItemId, setSrDialogItemId] = useState<number | null>(null)
 
   // Prefer a name passed via navigation state (the common path from TablesPage).
   // Fall back to a tables.list() lookup if the user landed on this URL directly
@@ -206,38 +207,14 @@ export function MenuPage() {
         onRetry={loadCategories}
       />
 
-      <button
-        type="button"
-        className="special-request-btn"
-        onClick={() => setShowSpecialRequestDialog(true)}
-        aria-label="Sonderwunsch hinzufügen"
-      >
-        <svg className="special-request-btn__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
-          <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
-          <polyline points="14 2 14 8 20 8" />
-          <line x1="12" y1="18" x2="12" y2="12" />
-          <line x1="9" y1="15" x2="15" y2="15" />
-        </svg>
-        <span className="special-request-btn__label">Sonderwunsch</span>
-        {specialRequests.length > 0 && (
-          <span className="special-request-btn__badge">{specialRequests.length}</span>
-        )}
-      </button>
-
-      {specialRequests.length > 0 && (
-        <SpecialRequestsList
-          requests={specialRequests}
-          onRemove={removeSpecialRequest}
-        />
-      )}
-
-      {showSpecialRequestDialog && (
+      {srDialogItemId != null && (
         <SpecialRequestDialog
+          itemName={lines[srDialogItemId]?.item.name ?? ''}
           onAdd={(text) => {
-            addSpecialRequest(text)
-            setShowSpecialRequestDialog(false)
+            addSpecialRequest(srDialogItemId, text)
+            setSrDialogItemId(null)
           }}
-          onClose={() => setShowSpecialRequestDialog(false)}
+          onClose={() => setSrDialogItemId(null)}
         />
       )}
 
@@ -247,12 +224,14 @@ export function MenuPage() {
         cart={lines}
         onAdd={addToCart}
         onRemove={removeFromCart}
+        onOpenSpecialRequest={(itemId) => setSrDialogItemId(itemId)}
+        onRemoveSpecialRequest={removeSpecialRequest}
         onRetry={() => {
           if (activeCategoryId != null) loadItems(activeCategoryId)
         }}
       />
 
-      {(count > 0 || specialRequests.length > 0) && (
+      {count > 0 && (
         <button
           type="button"
           className="next-cta"
@@ -263,7 +242,6 @@ export function MenuPage() {
           <span className="next-cta__info">
             <span className="next-cta__count" aria-label="Anzahl Artikel">
               {count} Artikel
-              {specialRequests.length > 0 && ` · ${specialRequests.length} Sonderw.`}
             </span>
             <span className="next-cta__sep" aria-hidden="true">
               ·
@@ -369,19 +347,22 @@ interface ItemsListProps {
   cart: Record<number, CartLine>
   onAdd: (item: MenuItemDto) => void
   onRemove: (item: MenuItemDto) => void
+  onOpenSpecialRequest: (itemId: number) => void
+  onRemoveSpecialRequest: (itemId: number, index: number) => void
   onRetry: () => void
 }
 
 // ---------------------------------------------------------------------------
-// Special request dialog
+// Special request dialog (per item)
 // ---------------------------------------------------------------------------
 
 interface SpecialRequestDialogProps {
+  itemName: string
   onAdd: (text: string) => void
   onClose: () => void
 }
 
-function SpecialRequestDialog({ onAdd, onClose }: SpecialRequestDialogProps) {
+function SpecialRequestDialog({ itemName, onAdd, onClose }: SpecialRequestDialogProps) {
   const [text, setText] = useState('')
   const inputRef = useRef<HTMLTextAreaElement>(null)
 
@@ -404,6 +385,7 @@ function SpecialRequestDialog({ onAdd, onClose }: SpecialRequestDialogProps) {
       <div className="sr-dialog">
         <div className="sr-dialog__header">
           <h3>Sonderwunsch</h3>
+          <span className="sr-dialog__item-name">{itemName}</span>
           <button
             type="button"
             className="sr-dialog__close"
@@ -444,34 +426,7 @@ function SpecialRequestDialog({ onAdd, onClose }: SpecialRequestDialogProps) {
 }
 
 // ---------------------------------------------------------------------------
-// Special requests list (shown on MenuPage when requests exist)
-// ---------------------------------------------------------------------------
-
-interface SpecialRequestsListProps {
-  requests: SpecialRequest[]
-  onRemove: (id: string) => void
-}
-
-function SpecialRequestsList({ requests, onRemove }: SpecialRequestsListProps) {
-  return (
-    <ul className="sr-list" aria-label="Sonderwünsche">
-      {requests.map((sr) => (
-        <li key={sr.id} className="sr-list__item">
-          <span className="sr-list__text">{sr.text}</span>
-          <button
-            type="button"
-            className="sr-list__remove"
-            onClick={() => onRemove(sr.id)}
-            aria-label="Sonderwunsch entfernen"
-          >&times;</button>
-        </li>
-      ))}
-    </ul>
-  )
-}
-
-// ---------------------------------------------------------------------------
-// Items list (stackable rows with +/- steppers)
+// Items list (stackable rows with +/- steppers and per-item special requests)
 // ---------------------------------------------------------------------------
 
 function ItemsList({
@@ -480,6 +435,8 @@ function ItemsList({
   cart,
   onAdd,
   onRemove,
+  onOpenSpecialRequest,
+  onRemoveSpecialRequest,
   onRetry,
 }: ItemsListProps) {
   if (activeCategoryId == null) {
@@ -527,8 +484,10 @@ function ItemsList({
   return (
     <ul className="menu-list" aria-label="Artikel">
       {state.items.map((item) => {
-        const qty = cart[item.id]?.qty ?? 0
+        const line = cart[item.id]
+        const qty = line?.qty ?? 0
         const inCart = qty > 0
+        const srs = line?.specialRequests ?? []
         return (
           <li
             key={item.id}
@@ -542,32 +501,70 @@ function ItemsList({
               <span className="menu-row__price">{formatPrice(item.price)}</span>
             </div>
 
-            <div
-              className="stepper"
-              role="group"
-              aria-label={`Anzahl ${item.name}`}
-            >
+            <div className="menu-row__actions">
               <button
                 type="button"
-                className="stepper__btn"
-                onClick={() => onRemove(item)}
-                disabled={qty === 0}
-                aria-label={`Eins weniger ${item.name}`}
+                className={`menu-row__sr-btn${srs.length > 0 ? ' menu-row__sr-btn--has' : ''}`}
+                onClick={() => {
+                  if (!inCart) onAdd(item)
+                  onOpenSpecialRequest(item.id)
+                }}
+                aria-label={`Sonderwunsch für ${item.name}`}
               >
-                −
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" width="20" height="20" aria-hidden="true">
+                  <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
+                  <polyline points="14 2 14 8 20 8" />
+                  <line x1="12" y1="18" x2="12" y2="12" />
+                  <line x1="9" y1="15" x2="15" y2="15" />
+                </svg>
+                {srs.length > 0 && (
+                  <span className="menu-row__sr-badge">{srs.length}</span>
+                )}
               </button>
-              <span className="stepper__value" aria-live="polite">
-                {qty}
-              </span>
-              <button
-                type="button"
-                className="stepper__btn stepper__btn--add"
-                onClick={() => onAdd(item)}
-                aria-label={`Eins mehr ${item.name}`}
+
+              <div
+                className="stepper"
+                role="group"
+                aria-label={`Anzahl ${item.name}`}
               >
-                +
-              </button>
+                <button
+                  type="button"
+                  className="stepper__btn"
+                  onClick={() => onRemove(item)}
+                  disabled={qty === 0}
+                  aria-label={`Eins weniger ${item.name}`}
+                >
+                  −
+                </button>
+                <span className="stepper__value" aria-live="polite">
+                  {qty}
+                </span>
+                <button
+                  type="button"
+                  className="stepper__btn stepper__btn--add"
+                  onClick={() => onAdd(item)}
+                  aria-label={`Eins mehr ${item.name}`}
+                >
+                  +
+                </button>
+              </div>
             </div>
+
+            {srs.length > 0 && (
+              <ul className="sr-list">
+                {srs.map((text, idx) => (
+                  <li key={idx} className="sr-list__item">
+                    <span className="sr-list__text">{text}</span>
+                    <button
+                      type="button"
+                      className="sr-list__remove"
+                      onClick={() => onRemoveSpecialRequest(item.id, idx)}
+                      aria-label="Sonderwunsch entfernen"
+                    >&times;</button>
+                  </li>
+                ))}
+              </ul>
+            )}
           </li>
         )
       })}

--- a/apps/waiter-web/src/pages/MenuPage.tsx
+++ b/apps/waiter-web/src/pages/MenuPage.tsx
@@ -3,7 +3,7 @@ import { useLocation, useNavigate, useParams } from 'react-router-dom'
 import type { MenuCategoryDto, MenuItemDto } from '@serva/shared-types'
 import { useApiClient } from '../hooks/useApiClient'
 import { useCart } from '../contexts/CartContext'
-import type { CartLine } from '../contexts/CartContext'
+import type { CartLine, SpecialRequest } from '../contexts/CartContext'
 
 // ---------------------------------------------------------------------------
 // Types & helpers
@@ -40,7 +40,12 @@ export function MenuPage() {
   const location = useLocation()
 
   // Cart state lives in context so it survives navigation between menu ↔ order.
-  const { lines, count, total, addItem, decrementItem, initForTable } = useCart()
+  const {
+    lines, count, total, addItem, decrementItem, initForTable,
+    specialRequests, addSpecialRequest, removeSpecialRequest,
+  } = useCart()
+
+  const [showSpecialRequestDialog, setShowSpecialRequestDialog] = useState(false)
 
   // Prefer a name passed via navigation state (the common path from TablesPage).
   // Fall back to a tables.list() lookup if the user landed on this URL directly
@@ -201,6 +206,41 @@ export function MenuPage() {
         onRetry={loadCategories}
       />
 
+      <button
+        type="button"
+        className="special-request-btn"
+        onClick={() => setShowSpecialRequestDialog(true)}
+        aria-label="Sonderwunsch hinzufügen"
+      >
+        <svg className="special-request-btn__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+          <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
+          <polyline points="14 2 14 8 20 8" />
+          <line x1="12" y1="18" x2="12" y2="12" />
+          <line x1="9" y1="15" x2="15" y2="15" />
+        </svg>
+        <span className="special-request-btn__label">Sonderwunsch</span>
+        {specialRequests.length > 0 && (
+          <span className="special-request-btn__badge">{specialRequests.length}</span>
+        )}
+      </button>
+
+      {specialRequests.length > 0 && (
+        <SpecialRequestsList
+          requests={specialRequests}
+          onRemove={removeSpecialRequest}
+        />
+      )}
+
+      {showSpecialRequestDialog && (
+        <SpecialRequestDialog
+          onAdd={(text) => {
+            addSpecialRequest(text)
+            setShowSpecialRequestDialog(false)
+          }}
+          onClose={() => setShowSpecialRequestDialog(false)}
+        />
+      )}
+
       <ItemsList
         state={itemsState}
         activeCategoryId={activeCategoryId}
@@ -212,7 +252,7 @@ export function MenuPage() {
         }}
       />
 
-      {count > 0 && (
+      {(count > 0 || specialRequests.length > 0) && (
         <button
           type="button"
           className="next-cta"
@@ -223,6 +263,7 @@ export function MenuPage() {
           <span className="next-cta__info">
             <span className="next-cta__count" aria-label="Anzahl Artikel">
               {count} Artikel
+              {specialRequests.length > 0 && ` · ${specialRequests.length} Sonderw.`}
             </span>
             <span className="next-cta__sep" aria-hidden="true">
               ·
@@ -330,6 +371,108 @@ interface ItemsListProps {
   onRemove: (item: MenuItemDto) => void
   onRetry: () => void
 }
+
+// ---------------------------------------------------------------------------
+// Special request dialog
+// ---------------------------------------------------------------------------
+
+interface SpecialRequestDialogProps {
+  onAdd: (text: string) => void
+  onClose: () => void
+}
+
+function SpecialRequestDialog({ onAdd, onClose }: SpecialRequestDialogProps) {
+  const [text, setText] = useState('')
+  const inputRef = useRef<HTMLTextAreaElement>(null)
+
+  useEffect(() => {
+    inputRef.current?.focus()
+  }, [])
+
+  const handleSubmit = () => {
+    const trimmed = text.trim()
+    if (trimmed) onAdd(trimmed)
+  }
+
+  return (
+    <div
+      className="sr-dialog-backdrop"
+      role="dialog"
+      aria-modal="true"
+      onClick={(e) => { if (e.target === e.currentTarget) onClose() }}
+    >
+      <div className="sr-dialog">
+        <div className="sr-dialog__header">
+          <h3>Sonderwunsch</h3>
+          <button
+            type="button"
+            className="sr-dialog__close"
+            onClick={onClose}
+            aria-label="Schliessen"
+          >&times;</button>
+        </div>
+        <div className="sr-dialog__body">
+          <textarea
+            ref={inputRef}
+            className="sr-dialog__input"
+            value={text}
+            onChange={(e) => setText(e.target.value)}
+            placeholder="z.B. ohne Zwiebeln, extra Sauce..."
+            maxLength={500}
+            rows={3}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' && !e.shiftKey) {
+                e.preventDefault()
+                handleSubmit()
+              }
+            }}
+          />
+        </div>
+        <div className="sr-dialog__footer">
+          <button
+            type="button"
+            className="btn-primary sr-dialog__add"
+            onClick={handleSubmit}
+            disabled={text.trim().length === 0}
+          >
+            Hinzufügen
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Special requests list (shown on MenuPage when requests exist)
+// ---------------------------------------------------------------------------
+
+interface SpecialRequestsListProps {
+  requests: SpecialRequest[]
+  onRemove: (id: string) => void
+}
+
+function SpecialRequestsList({ requests, onRemove }: SpecialRequestsListProps) {
+  return (
+    <ul className="sr-list" aria-label="Sonderwünsche">
+      {requests.map((sr) => (
+        <li key={sr.id} className="sr-list__item">
+          <span className="sr-list__text">{sr.text}</span>
+          <button
+            type="button"
+            className="sr-list__remove"
+            onClick={() => onRemove(sr.id)}
+            aria-label="Sonderwunsch entfernen"
+          >&times;</button>
+        </li>
+      ))}
+    </ul>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Items list (stackable rows with +/- steppers)
+// ---------------------------------------------------------------------------
 
 function ItemsList({
   state,

--- a/apps/waiter-web/src/pages/OrderPage.tsx
+++ b/apps/waiter-web/src/pages/OrderPage.tsx
@@ -50,13 +50,11 @@ function formatPrice(value: number): string {
   return eurFormatter.format(value)
 }
 
-function toOrderItems(lines: CartLine[]) {
-  return lines.map((line) => ({
+function toOrderItems(lines: CartLine[], specialRequests?: string) {
+  return lines.map((line, index) => ({
     menuItemId: line.item.id,
     quantity: line.qty,
-    ...(line.specialRequests.trim()
-      ? { specialRequests: line.specialRequests.trim() }
-      : {}),
+    ...(index === 0 && specialRequests ? { specialRequests } : {}),
   }))
 }
 
@@ -112,10 +110,11 @@ export function OrderPage() {
     extraCount,
     setQuantity,
     removeItem,
-    setSpecialRequests,
     toggleExtra,
     clearCart,
     payItems,
+    specialRequests,
+    removeSpecialRequest,
   } = useCart()
 
   const tableName =
@@ -188,12 +187,14 @@ export function OrderPage() {
     const hasExtra = extraLines.length > 0
 
     try {
+      const srText = specialRequests.map((sr) => sr.text).join('; ') || undefined
+
       const created: Array<{ orderId: number; label: string }> = []
 
       if (hasRegular) {
         const order = await client.orders.create({
           tableId: tableIdNum,
-          items: toOrderItems(regularLines),
+          items: toOrderItems(regularLines, srText),
         })
         created.push({ orderId: order.id, label: 'Bestellung' })
       }
@@ -201,7 +202,7 @@ export function OrderPage() {
       if (hasExtra) {
         const order = await client.orders.create({
           tableId: tableIdNum,
-          items: toOrderItems(extraLines),
+          items: toOrderItems(extraLines, hasRegular ? undefined : srText),
         })
         created.push({ orderId: order.id, label: 'Extras' })
       }
@@ -292,7 +293,7 @@ export function OrderPage() {
       setSubmitError(errorCodeToMessage(err))
       setSubmitting(false)
     }
-  }, [client, lineList, regularLines, extraLines, tableId, clearCart, navigate])
+  }, [client, lineList, regularLines, extraLines, tableId, clearCart, navigate, specialRequests])
 
   // ── Navigation ─────────────────────────────────────────────────────────
 
@@ -362,7 +363,6 @@ export function OrderPage() {
                 openQty={openQty}
                 onSetQuantity={(qty) => setQuantity(line.item.id, qty)}
                 onRemove={() => removeItem(line.item.id)}
-                onSetSpecialRequests={(text) => setSpecialRequests(line.item.id, text)}
                 onToggleExtra={() => {
                   toggleExtra(line.item.id)
                   setExtrasOpen(true)
@@ -372,6 +372,35 @@ export function OrderPage() {
             )
           })}
         </ul>
+      )}
+
+      {/* Special requests */}
+      {specialRequests.length > 0 && (
+        <div className="order-special-requests" aria-label="Sonderwünsche">
+          <div className="order-special-requests__header">
+            <svg className="order-special-requests__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" width="16" height="16" aria-hidden="true">
+              <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
+              <polyline points="14 2 14 8 20 8" />
+              <line x1="12" y1="18" x2="12" y2="12" />
+              <line x1="9" y1="15" x2="15" y2="15" />
+            </svg>
+            <span>Sonderw&#252;nsche</span>
+          </div>
+          <ul className="order-special-requests__list">
+            {specialRequests.map((sr) => (
+              <li key={sr.id} className="order-special-requests__item">
+                <span className="order-special-requests__text">{sr.text}</span>
+                <button
+                  type="button"
+                  className="order-special-requests__remove"
+                  onClick={() => removeSpecialRequest(sr.id)}
+                  disabled={submitting}
+                  aria-label="Sonderwunsch entfernen"
+                >&#215;</button>
+              </li>
+            ))}
+          </ul>
+        </div>
       )}
 
       {/* Extras accordion */}
@@ -415,7 +444,6 @@ export function OrderPage() {
                       openQty={openQty}
                       onSetQuantity={(qty) => setQuantity(line.item.id, qty)}
                       onRemove={() => removeItem(line.item.id)}
-                      onSetSpecialRequests={(text) => setSpecialRequests(line.item.id, text)}
                       onToggleExtra={() => toggleExtra(line.item.id)}
                       onSetSubBillQty={(qty) => setSubBillQty(line.item.id, qty)}
                     />
@@ -500,7 +528,6 @@ interface CartItemRowProps {
   openQty: number
   onSetQuantity(qty: number): void
   onRemove(): void
-  onSetSpecialRequests(text: string): void
   onToggleExtra(): void
   onSetSubBillQty(qty: number): void
 }
@@ -513,11 +540,10 @@ function CartItemRow({
   openQty,
   onSetQuantity,
   onRemove,
-  onSetSpecialRequests,
   onToggleExtra,
   onSetSubBillQty,
 }: CartItemRowProps) {
-  const { item, qty, specialRequests, isExtra, paidQty } = line
+  const { item, qty, isExtra, paidQty } = line
   const lineTotal = qty * item.price
 
   return (
@@ -638,22 +664,6 @@ function CartItemRow({
         )}
       </div>
 
-      <label className="order-row__special">
-        <span className="order-row__special-label">
-          Sonderw&#252;nsche
-          <span className="order-row__special-optional"> (optional)</span>
-        </span>
-        <textarea
-          className="order-row__special-input"
-          value={specialRequests}
-          onChange={(e) => onSetSpecialRequests(e.target.value)}
-          placeholder="z. B. ohne Zwiebeln, extra Sauce..."
-          maxLength={500}
-          rows={2}
-          disabled={disabled}
-          aria-label={`Sonderwuensche fuer ${item.name}`}
-        />
-      </label>
     </li>
   )
 }

--- a/apps/waiter-web/src/pages/OrderPage.tsx
+++ b/apps/waiter-web/src/pages/OrderPage.tsx
@@ -50,12 +50,15 @@ function formatPrice(value: number): string {
   return eurFormatter.format(value)
 }
 
-function toOrderItems(lines: CartLine[], specialRequests?: string) {
-  return lines.map((line, index) => ({
-    menuItemId: line.item.id,
-    quantity: line.qty,
-    ...(index === 0 && specialRequests ? { specialRequests } : {}),
-  }))
+function toOrderItems(lines: CartLine[]) {
+  return lines.map((line) => {
+    const sr = line.specialRequests.join('; ').trim()
+    return {
+      menuItemId: line.item.id,
+      quantity: line.qty,
+      ...(sr ? { specialRequests: sr } : {}),
+    }
+  })
 }
 
 function errorCodeToMessage(err: unknown): string {
@@ -113,7 +116,6 @@ export function OrderPage() {
     toggleExtra,
     clearCart,
     payItems,
-    specialRequests,
     removeSpecialRequest,
   } = useCart()
 
@@ -187,14 +189,12 @@ export function OrderPage() {
     const hasExtra = extraLines.length > 0
 
     try {
-      const srText = specialRequests.map((sr) => sr.text).join('; ') || undefined
-
       const created: Array<{ orderId: number; label: string }> = []
 
       if (hasRegular) {
         const order = await client.orders.create({
           tableId: tableIdNum,
-          items: toOrderItems(regularLines, srText),
+          items: toOrderItems(regularLines),
         })
         created.push({ orderId: order.id, label: 'Bestellung' })
       }
@@ -202,7 +202,7 @@ export function OrderPage() {
       if (hasExtra) {
         const order = await client.orders.create({
           tableId: tableIdNum,
-          items: toOrderItems(extraLines, hasRegular ? undefined : srText),
+          items: toOrderItems(extraLines),
         })
         created.push({ orderId: order.id, label: 'Extras' })
       }
@@ -293,7 +293,7 @@ export function OrderPage() {
       setSubmitError(errorCodeToMessage(err))
       setSubmitting(false)
     }
-  }, [client, lineList, regularLines, extraLines, tableId, clearCart, navigate, specialRequests])
+  }, [client, lineList, regularLines, extraLines, tableId, clearCart, navigate])
 
   // ── Navigation ─────────────────────────────────────────────────────────
 
@@ -368,39 +368,11 @@ export function OrderPage() {
                   setExtrasOpen(true)
                 }}
                 onSetSubBillQty={(qty) => setSubBillQty(line.item.id, qty)}
+                onRemoveSpecialRequest={(idx) => removeSpecialRequest(line.item.id, idx)}
               />
             )
           })}
         </ul>
-      )}
-
-      {/* Special requests */}
-      {specialRequests.length > 0 && (
-        <div className="order-special-requests" aria-label="Sonderwünsche">
-          <div className="order-special-requests__header">
-            <svg className="order-special-requests__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" width="16" height="16" aria-hidden="true">
-              <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
-              <polyline points="14 2 14 8 20 8" />
-              <line x1="12" y1="18" x2="12" y2="12" />
-              <line x1="9" y1="15" x2="15" y2="15" />
-            </svg>
-            <span>Sonderw&#252;nsche</span>
-          </div>
-          <ul className="order-special-requests__list">
-            {specialRequests.map((sr) => (
-              <li key={sr.id} className="order-special-requests__item">
-                <span className="order-special-requests__text">{sr.text}</span>
-                <button
-                  type="button"
-                  className="order-special-requests__remove"
-                  onClick={() => removeSpecialRequest(sr.id)}
-                  disabled={submitting}
-                  aria-label="Sonderwunsch entfernen"
-                >&#215;</button>
-              </li>
-            ))}
-          </ul>
-        </div>
       )}
 
       {/* Extras accordion */}
@@ -446,6 +418,7 @@ export function OrderPage() {
                       onRemove={() => removeItem(line.item.id)}
                       onToggleExtra={() => toggleExtra(line.item.id)}
                       onSetSubBillQty={(qty) => setSubBillQty(line.item.id, qty)}
+                      onRemoveSpecialRequest={(idx) => removeSpecialRequest(line.item.id, idx)}
                     />
                   )
                 })}
@@ -530,6 +503,7 @@ interface CartItemRowProps {
   onRemove(): void
   onToggleExtra(): void
   onSetSubBillQty(qty: number): void
+  onRemoveSpecialRequest(index: number): void
 }
 
 function CartItemRow({
@@ -542,8 +516,9 @@ function CartItemRow({
   onRemove,
   onToggleExtra,
   onSetSubBillQty,
+  onRemoveSpecialRequest,
 }: CartItemRowProps) {
-  const { item, qty, isExtra, paidQty } = line
+  const { item, qty, specialRequests, isExtra, paidQty } = line
   const lineTotal = qty * item.price
 
   return (
@@ -664,6 +639,22 @@ function CartItemRow({
         )}
       </div>
 
+      {specialRequests.length > 0 && (
+        <ul className="sr-list sr-list--order" aria-label={`Sonderwünsche für ${item.name}`}>
+          {specialRequests.map((text, idx) => (
+            <li key={idx} className="sr-list__item">
+              <span className="sr-list__text">{text}</span>
+              <button
+                type="button"
+                className="sr-list__remove"
+                onClick={() => onRemoveSpecialRequest(idx)}
+                disabled={disabled}
+                aria-label="Sonderwunsch entfernen"
+              >&times;</button>
+            </li>
+          ))}
+        </ul>
+      )}
     </li>
   )
 }

--- a/apps/waiter-web/src/pages/OrderPage.tsx
+++ b/apps/waiter-web/src/pages/OrderPage.tsx
@@ -51,17 +51,19 @@ function formatPrice(value: number): string {
 }
 
 function toOrderItems(lines: CartLine[]) {
-  return lines.map((line) => {
-    const sr = line.specialRequests
-      .map((s) => s.qty > 1 ? `${s.qty}x ${s.text}` : s.text)
-      .join('; ')
-      .trim()
-    return {
-      menuItemId: line.item.id,
-      quantity: line.qty,
-      ...(sr ? { specialRequests: sr } : {}),
-    }
-  })
+  return lines
+    .filter((line) => line.qty > 0 || line.specialRequests.length > 0)
+    .map((line) => {
+      const sr = line.specialRequests
+        .map((s) => s.qty > 1 ? `${s.qty}x ${s.text}` : s.text)
+        .join('; ')
+        .trim()
+      return {
+        menuItemId: line.item.id,
+        quantity: line.qty,
+        ...(sr ? { specialRequests: sr } : {}),
+      }
+    })
 }
 
 function errorCodeToMessage(err: unknown): string {
@@ -331,6 +333,8 @@ export function OrderPage() {
 
   // ── Empty cart ─────────────────────────────────────────────────────────
 
+  const hasOrderableItems = lineList.some((l) => l.qty > 0 || l.specialRequests.length > 0)
+
   if (lineList.length === 0 && !printResult) {
     return (
       <div className="page order-page">
@@ -484,7 +488,7 @@ export function OrderPage() {
           type="button"
           className="btn-primary btn-place-order"
           onClick={handleSubmit}
-          disabled={submitting || lineList.length === 0}
+          disabled={submitting || !hasOrderableItems}
         >
           {submitting ? 'Wird gesendet…' : 'Bestellen'}
         </button>

--- a/apps/waiter-web/src/pages/OrderPage.tsx
+++ b/apps/waiter-web/src/pages/OrderPage.tsx
@@ -52,7 +52,10 @@ function formatPrice(value: number): string {
 
 function toOrderItems(lines: CartLine[]) {
   return lines.map((line) => {
-    const sr = line.specialRequests.join('; ').trim()
+    const sr = line.specialRequests
+      .map((s) => s.qty > 1 ? `${s.qty}x ${s.text}` : s.text)
+      .join('; ')
+      .trim()
     return {
       menuItemId: line.item.id,
       quantity: line.qty,
@@ -116,7 +119,7 @@ export function OrderPage() {
     toggleExtra,
     clearCart,
     payItems,
-    removeSpecialRequest,
+    setSpecialRequestQty,
   } = useCart()
 
   const tableName =
@@ -368,7 +371,8 @@ export function OrderPage() {
                   setExtrasOpen(true)
                 }}
                 onSetSubBillQty={(qty) => setSubBillQty(line.item.id, qty)}
-                onRemoveSpecialRequest={(idx) => removeSpecialRequest(line.item.id, idx)}
+
+                onSetSpecialRequestQty={(idx, qty) => setSpecialRequestQty(line.item.id, idx, qty)}
               />
             )
           })}
@@ -418,7 +422,8 @@ export function OrderPage() {
                       onRemove={() => removeItem(line.item.id)}
                       onToggleExtra={() => toggleExtra(line.item.id)}
                       onSetSubBillQty={(qty) => setSubBillQty(line.item.id, qty)}
-                      onRemoveSpecialRequest={(idx) => removeSpecialRequest(line.item.id, idx)}
+      
+                      onSetSpecialRequestQty={(idx, qty) => setSpecialRequestQty(line.item.id, idx, qty)}
                     />
                   )
                 })}
@@ -503,7 +508,7 @@ interface CartItemRowProps {
   onRemove(): void
   onToggleExtra(): void
   onSetSubBillQty(qty: number): void
-  onRemoveSpecialRequest(index: number): void
+  onSetSpecialRequestQty(index: number, qty: number): void
 }
 
 function CartItemRow({
@@ -516,7 +521,7 @@ function CartItemRow({
   onRemove,
   onToggleExtra,
   onSetSubBillQty,
-  onRemoveSpecialRequest,
+  onSetSpecialRequestQty,
 }: CartItemRowProps) {
   const { item, qty, specialRequests, isExtra, paidQty } = line
   const lineTotal = qty * item.price
@@ -641,16 +646,26 @@ function CartItemRow({
 
       {specialRequests.length > 0 && (
         <ul className="sr-list sr-list--order" aria-label={`Sonderwünsche für ${item.name}`}>
-          {specialRequests.map((text, idx) => (
+          {specialRequests.map((sr, idx) => (
             <li key={idx} className="sr-list__item">
-              <span className="sr-list__text">{text}</span>
-              <button
-                type="button"
-                className="sr-list__remove"
-                onClick={() => onRemoveSpecialRequest(idx)}
-                disabled={disabled}
-                aria-label="Sonderwunsch entfernen"
-              >&times;</button>
+              <span className="sr-list__text">{sr.text}</span>
+              <div className="stepper sr-list__stepper" role="group" aria-label={`Anzahl: ${sr.text}`}>
+                <button
+                  type="button"
+                  className="stepper__btn"
+                  onClick={() => onSetSpecialRequestQty(idx, sr.qty - 1)}
+                  disabled={disabled}
+                  aria-label="Eins weniger"
+                >&#8722;</button>
+                <span className="stepper__value">{sr.qty}</span>
+                <button
+                  type="button"
+                  className="stepper__btn stepper__btn--add"
+                  onClick={() => onSetSpecialRequestQty(idx, sr.qty + 1)}
+                  disabled={disabled}
+                  aria-label="Eins mehr"
+                >+</button>
+              </div>
             </li>
           ))}
         </ul>

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -109,7 +109,7 @@ export const OrderItemsSchema = z
   .object({
     order_id: positiveInt,
     menuItem_id: positiveInt,
-    quantity: z.number().int().positive(),
+    quantity: z.number().int().nonnegative(),
     specialRequests: z.string(),
   })
   .strict();
@@ -680,7 +680,7 @@ export type ConfigPatchResponse = ConfigGetResponse;
 export const OrderSubmitItemRequestSchema = z
   .object({
     menuItemId: positiveInt,
-    quantity: z.number().int().positive(),
+    quantity: z.number().int().nonnegative(),
     specialRequests: z.string().trim().max(500).optional(),
   })
   .strict();
@@ -692,7 +692,7 @@ export const OrderItemDtoSchema = z
   .object({
     id: positiveInt,
     menuItemId: positiveInt,
-    quantity: z.number().int().positive(),
+    quantity: z.number().int().nonnegative(),
     specialRequests: z.string().trim().max(500).optional(),
   })
   .strict();


### PR DESCRIPTION
## Summary
- Move special requests from per-item textareas on the cart/order-review screen to the menu page (order screen) as standalone entries
- Add a dedicated special request button with an icon on the menu page; each tap opens a dialog to create a new independent request
- Display special requests as a removable list on both the menu page and the order review page
- On submission, all special requests are concatenated and attached to the first order item's `specialRequests` field

## Changes
- **CartContext**: Replace `specialRequests: string` on `CartLine` with a top-level `specialRequests: SpecialRequest[]` array; add `addSpecialRequest` / `removeSpecialRequest` methods
- **MenuPage**: Add `SpecialRequestDialog` modal and `SpecialRequestsList` component; show badge count on button and in bottom CTA
- **OrderPage**: Remove per-item special request textarea from `CartItemRow`; add read-only special requests section; update `toOrderItems` to concatenate and attach to first item
- **CSS**: Add styles for special request button, dialog, inline list (menu page), and order page section

Closes #92

## Test plan
- [ ] Open waiter order flow, choose a table
- [ ] Verify the special request button with icon appears on the menu page
- [ ] Tap the button, enter text, confirm it appears in the list below
- [ ] Tap the button again to add a second special request - verify both show independently
- [ ] Remove a special request via the x button
- [ ] Verify the bottom CTA shows special request count when requests exist
- [ ] Navigate to the order review page - verify special requests section appears
- [ ] Verify per-item special request textareas are gone
- [ ] Submit an order with special requests - verify they appear on the printed bon / in order details
- [ ] Verify orders without special requests still work correctly
