### PR TITLE
Serva-94 feat: admin-to-waiter announcements

### DIFF
--- a/apps/admin-desktop/src/pages/LogsPage.tsx
+++ b/apps/admin-desktop/src/pages/LogsPage.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import type { LogEntryDto, LogLevel } from "@serva/shared-types";
+import type { AnnouncementSeverity, LogEntryDto, LogLevel } from "@serva/shared-types";
 import { useApiClient } from "../contexts/ApiClientContext";
 
 // Display labels mirror the German UI copy in the rest of the admin app.
@@ -28,6 +28,111 @@ type LoadState =
   | { status: "error"; message: string }
   | { status: "ok" };
 
+// ---------------------------------------------------------------------------
+// AnnouncementModal
+// ---------------------------------------------------------------------------
+
+const SEVERITY_OPTIONS: ReadonlyArray<{ value: AnnouncementSeverity; label: string }> = [
+  { value: "info", label: "Info" },
+  { value: "warning", label: "Warnung" },
+  { value: "urgent", label: "Dringend" },
+];
+
+interface AnnouncementModalProps {
+  onClose: () => void;
+  onSave: (message: string, severity: AnnouncementSeverity) => Promise<void>;
+  saving: boolean;
+  saveError: string | null;
+}
+
+function AnnouncementModal({ onClose, onSave, saving, saveError }: AnnouncementModalProps) {
+  const [message, setMessage] = useState("");
+  const [severity, setSeverity] = useState<AnnouncementSeverity>("info");
+  const msgRef = useRef<HTMLTextAreaElement>(null);
+
+  useEffect(() => {
+    setTimeout(() => msgRef.current?.focus(), 50);
+  }, []);
+
+  const canSubmit = message.trim().length > 0;
+
+  return (
+    <div
+      className="modal-overlay"
+      role="dialog"
+      aria-modal="true"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onClose();
+      }}
+    >
+      <div className="modal-card" style={{ width: 480 }}>
+        <h3 className="modal-title">Neue Ansage</h3>
+        <p className="modal-subtitle">Wird allen Kellnern angezeigt.</p>
+
+        <form
+          onSubmit={(e) => {
+            e.preventDefault();
+            if (canSubmit) onSave(message.trim(), severity);
+          }}
+        >
+          <div className="form-group">
+            <label className="form-label" htmlFor="ann-msg">
+              Nachricht <span className="required-star">*</span>
+            </label>
+            <textarea
+              id="ann-msg"
+              ref={msgRef}
+              className="form-input"
+              rows={3}
+              value={message}
+              onChange={(e) => setMessage(e.target.value)}
+              required
+              maxLength={500}
+              placeholder="z. B. Küche schließt in 30 Minuten"
+            />
+          </div>
+
+          <div className="form-group">
+            <label className="form-label" htmlFor="ann-sev">Priorität</label>
+            <select
+              id="ann-sev"
+              className="form-input"
+              value={severity}
+              onChange={(e) => setSeverity(e.target.value as AnnouncementSeverity)}
+            >
+              {SEVERITY_OPTIONS.map((opt) => (
+                <option key={opt.value} value={opt.value}>
+                  {opt.label}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          {saveError && <p className="form-error">{saveError}</p>}
+
+          <div className="modal-footer">
+            <button
+              type="button"
+              className="btn-secondary"
+              onClick={onClose}
+              disabled={saving}
+            >
+              Abbrechen
+            </button>
+            <button
+              type="submit"
+              className="btn-primary modal-submit"
+              disabled={saving || !canSubmit}
+            >
+              {saving ? "Wird gesendet…" : "Senden"}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}
+
 function formatTime(iso: string): string {
   const d = new Date(iso);
   if (Number.isNaN(d.getTime())) return iso;
@@ -54,6 +159,11 @@ export function LogsPage() {
   const [minLevel, setMinLevel] = useState<LogLevel>("info");
   const [autoRefresh, setAutoRefresh] = useState(true);
   const [search, setSearch] = useState("");
+
+  // Announcement modal
+  const [annOpen, setAnnOpen] = useState(false);
+  const [annSaving, setAnnSaving] = useState(false);
+  const [annError, setAnnError] = useState<string | null>(null);
 
   // We tear down/recreate the poll timer whenever the level filter or
   // auto-refresh toggle flips, so a stale interval can't keep running.
@@ -132,6 +242,19 @@ export function LogsPage() {
     });
   }, [entries, search]);
 
+  async function handleAnnSave(message: string, severity: AnnouncementSeverity) {
+    setAnnSaving(true);
+    setAnnError(null);
+    try {
+      await api.announcements.create({ message, severity });
+      setAnnOpen(false);
+    } catch (err) {
+      setAnnError(err instanceof Error ? err.message : "Fehler beim Senden.");
+    } finally {
+      setAnnSaving(false);
+    }
+  }
+
   return (
     <div className="logs-page">
       <div className="page-header">
@@ -170,6 +293,16 @@ export function LogsPage() {
           >
             Aktualisieren
           </button>
+          <button
+            type="button"
+            className="btn-primary"
+            onClick={() => {
+              setAnnError(null);
+              setAnnOpen(true);
+            }}
+          >
+            Neue Ansage
+          </button>
         </div>
       </div>
 
@@ -198,6 +331,15 @@ export function LogsPage() {
           ))
         )}
       </div>
+
+      {annOpen && (
+        <AnnouncementModal
+          onClose={() => setAnnOpen(false)}
+          onSave={handleAnnSave}
+          saving={annSaving}
+          saveError={annError}
+        />
+      )}
     </div>
   );
 }

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -18,6 +18,7 @@ import { registerJwtAuthGuard } from "./plugins/jwt-auth-guard";
 import { createLogBufferStream, logBuffer } from "./plugins/log-buffer";
 import { registerLogRoutes } from "./routes/logs";
 import { registerAdminEventRoutes } from "./routes/admin-events";
+import { registerAnnouncementRoutes } from "./routes/announcements";
 import { registerAuthRoutes } from "./routes/auth";
 import { registerConfigRoutes } from "./routes/config";
 import { registerMenuRoutes } from "./routes/menu";
@@ -121,6 +122,7 @@ export async function buildApp(options: BuildAppOptions = {}) {
       },
       tags: [
         { name: "admin-events", description: "Admin event lifecycle endpoints" },
+        { name: "announcements", description: "Admin-to-waiter announcements" },
         { name: "auth", description: "Authentication endpoints" },
         { name: "config", description: "Event configuration endpoints" },
         { name: "menu", description: "Menu categories and items" },
@@ -221,6 +223,7 @@ export async function buildApp(options: BuildAppOptions = {}) {
   registerActiveEventGuard(app);
   registerOpsRoutes(app);
   registerAdminEventRoutes(app);
+  registerAnnouncementRoutes(app);
   registerAuthRoutes(app);
   registerConfigRoutes(app);
   registerPrinterRoutes(app);

--- a/apps/api/src/domain/announcement-store.ts
+++ b/apps/api/src/domain/announcement-store.ts
@@ -1,0 +1,108 @@
+import Database from "better-sqlite3";
+import type {
+  AnnouncementCreateRequest,
+  AnnouncementDto,
+  AnnouncementsQuery,
+} from "@serva/shared-types";
+import { ApiError } from "./api-error";
+import type { EventStore } from "./event-store";
+
+type AnnouncementRow = {
+  id: number;
+  message: string;
+  severity: string;
+  createdAt: string;
+  createdBy: string;
+};
+
+export class AnnouncementStore {
+  constructor(private readonly eventStore: EventStore) {}
+
+  private openActiveEventDb() {
+    const activeEvent = this.eventStore.getActiveEvent();
+    if (!activeEvent) {
+      throw new ApiError(
+        409,
+        "NO_ACTIVE_EVENT",
+        "No active event exists. Activate an event before calling this endpoint."
+      );
+    }
+
+    const db = new Database(activeEvent.dbFilePath);
+    this.ensureSchema(db);
+    return db;
+  }
+
+  private ensureSchema(db: Database.Database) {
+    db.exec(`
+      CREATE TABLE IF NOT EXISTS Announcements (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        message TEXT NOT NULL,
+        severity TEXT NOT NULL DEFAULT 'info',
+        createdAt TEXT NOT NULL,
+        createdBy TEXT NOT NULL
+      );
+    `);
+  }
+
+  private toDto(row: AnnouncementRow): AnnouncementDto {
+    return {
+      id: row.id,
+      message: row.message,
+      severity: row.severity as AnnouncementDto["severity"],
+      createdAt: row.createdAt,
+      createdBy: row.createdBy,
+    };
+  }
+
+  list(query: AnnouncementsQuery): AnnouncementDto[] {
+    const db = this.openActiveEventDb();
+    try {
+      if (query.since != null) {
+        const rows = db
+          .prepare(
+            "SELECT id, message, severity, createdAt, createdBy FROM Announcements WHERE id > ? ORDER BY id ASC"
+          )
+          .all(query.since) as AnnouncementRow[];
+        return rows.map((r) => this.toDto(r));
+      }
+
+      const rows = db
+        .prepare(
+          "SELECT id, message, severity, createdAt, createdBy FROM Announcements ORDER BY id DESC LIMIT 100"
+        )
+        .all() as AnnouncementRow[];
+      return rows.map((r) => this.toDto(r));
+    } finally {
+      db.close();
+    }
+  }
+
+  create(input: AnnouncementCreateRequest, createdBy: string): AnnouncementDto {
+    const db = this.openActiveEventDb();
+    try {
+      const now = new Date().toISOString();
+      const severity = input.severity ?? "info";
+
+      const result = db
+        .prepare(
+          "INSERT INTO Announcements (message, severity, createdAt, createdBy) VALUES (?, ?, ?, ?)"
+        )
+        .run(input.message, severity, now, createdBy);
+
+      const row = db
+        .prepare(
+          "SELECT id, message, severity, createdAt, createdBy FROM Announcements WHERE id = ?"
+        )
+        .get(Number(result.lastInsertRowid)) as AnnouncementRow | undefined;
+
+      if (!row) {
+        throw new ApiError(500, "ANNOUNCEMENT_CREATE_FAILED", "Failed to create announcement");
+      }
+
+      return this.toDto(row);
+    } finally {
+      db.close();
+    }
+  }
+}

--- a/apps/api/src/domain/state.ts
+++ b/apps/api/src/domain/state.ts
@@ -1,4 +1,5 @@
-﻿import { AuthStore } from "./auth-store";
+﻿import { AnnouncementStore } from "./announcement-store";
+import { AuthStore } from "./auth-store";
 import { ConfigStore } from "./config-store";
 import { EventStore } from "./event-store";
 import { MenuStore } from "./menu-store";
@@ -10,6 +11,7 @@ import { TableStore } from "./table-store";
 import { UserStore } from "./user-store";
 
 export const eventStore = new EventStore();
+export const announcementStore = new AnnouncementStore(eventStore);
 export const configStore = new ConfigStore(eventStore);
 export const userStore = new UserStore(eventStore);
 export const authStore = new AuthStore(eventStore, userStore);

--- a/apps/api/src/routes/announcements.ts
+++ b/apps/api/src/routes/announcements.ts
@@ -1,0 +1,79 @@
+import {
+  AnnouncementCreateRequest,
+  AnnouncementCreateRequestSchema,
+  AnnouncementCreateResponseSchema,
+  AnnouncementsQuery,
+  AnnouncementsQuerySchema,
+  AnnouncementsResponseSchema,
+  ApiErrorEnvelopeSchema,
+} from "@serva/shared-types";
+import type { FastifyInstance } from "fastify";
+import { announcementStore } from "../domain/state";
+
+export function registerAnnouncementRoutes(app: FastifyInstance) {
+  app.get<{ Querystring: AnnouncementsQuery }>(
+    "/announcements",
+    {
+      config: {
+        requiresAuth: true,
+        allowedRoles: ["admin", "waiter"],
+        requiresActiveEvent: true,
+      },
+      schema: {
+        tags: ["announcements"],
+        operationId: "announcementsList",
+        summary: "Ansagen auflisten",
+        description:
+          "Liefert Ansagen des aktiven Events. Mit ?since=<id> nur neuere Eintraege.",
+        security: [{ bearerAuth: [] }],
+        querystring: AnnouncementsQuerySchema,
+        response: {
+          200: AnnouncementsResponseSchema,
+          401: ApiErrorEnvelopeSchema,
+          403: ApiErrorEnvelopeSchema,
+          409: ApiErrorEnvelopeSchema,
+        },
+      },
+    },
+    async (request) => ({
+      announcements: announcementStore.list(request.query),
+    })
+  );
+
+  app.post<{ Body: AnnouncementCreateRequest }>(
+    "/announcements",
+    {
+      config: {
+        requiresRole: "admin",
+        requiresActiveEvent: true,
+      },
+      schema: {
+        tags: ["announcements"],
+        operationId: "announcementsCreate",
+        summary: "Neue Ansage erstellen",
+        description: "Erstellt eine Ansage, die alle Kellner sehen.",
+        security: [{ bearerAuth: [] }],
+        body: AnnouncementCreateRequestSchema,
+        response: {
+          201: AnnouncementCreateResponseSchema,
+          400: ApiErrorEnvelopeSchema,
+          401: ApiErrorEnvelopeSchema,
+          403: ApiErrorEnvelopeSchema,
+          409: ApiErrorEnvelopeSchema,
+        },
+      },
+    },
+    async (request, reply) => {
+      const createdBy = request.auth.username ?? request.auth.role;
+
+      const created = announcementStore.create(request.body, createdBy);
+
+      app.log.info(
+        { announcementId: created.id, severity: created.severity },
+        `Ansage erstellt: ${created.message}`
+      );
+
+      return reply.status(201).send(created);
+    }
+  );
+}

--- a/apps/api/src/routes/stock.ts
+++ b/apps/api/src/routes/stock.ts
@@ -16,7 +16,9 @@
   StockItemUpdateResponseSchema,
 } from "@serva/shared-types";
 import type { FastifyInstance } from "fastify";
-import { stockStore } from "../domain/state";
+import { announcementStore, configStore, stockStore } from "../domain/state";
+
+const DEFAULT_LOW_STOCK_THRESHOLD = 5;
 
 export function registerStockRoutes(app: FastifyInstance) {
   app.get(
@@ -99,7 +101,45 @@ export function registerStockRoutes(app: FastifyInstance) {
         },
       },
     },
-    async (request) => stockStore.updateItem(request.params.stockItemId, request.body)
+    async (request) => {
+      const updated = stockStore.updateItem(request.params.stockItemId, request.body);
+
+      try {
+        const config = configStore.listValues();
+        const threshold = parseInt(config["stockLowThreshold"] ?? "", 10);
+        const limit = isNaN(threshold) ? DEFAULT_LOW_STOCK_THRESHOLD : threshold;
+
+        if (updated.quantity > 0 && updated.quantity <= limit) {
+          announcementStore.create(
+            {
+              message: `Lager niedrig: „${updated.name}" hat nur noch ${updated.quantity} Stück.`,
+              severity: "warning",
+            },
+            "System"
+          );
+          app.log.warn(
+            { stockItemId: updated.id, quantity: updated.quantity },
+            `Lager niedrig: ${updated.name} (${updated.quantity})`
+          );
+        } else if (updated.quantity === 0) {
+          announcementStore.create(
+            {
+              message: `Lager leer: „${updated.name}" ist aufgebraucht!`,
+              severity: "urgent",
+            },
+            "System"
+          );
+          app.log.warn(
+            { stockItemId: updated.id },
+            `Lager leer: ${updated.name}`
+          );
+        }
+      } catch {
+        // Don't fail the stock update if announcement creation fails
+      }
+
+      return updated;
+    }
   );
 
   app.get<{ Params: MenuItemParams }>(

--- a/apps/waiter-web/src/components/AnnouncementOverlay.tsx
+++ b/apps/waiter-web/src/components/AnnouncementOverlay.tsx
@@ -1,0 +1,93 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import type { AnnouncementDto } from '@serva/shared-types'
+import { useApiClient } from '../hooks/useApiClient'
+
+const POLL_INTERVAL_MS = 5000
+
+export function AnnouncementOverlay() {
+  const api = useApiClient()
+  const [queue, setQueue] = useState<AnnouncementDto[]>([])
+  const lastIdRef = useRef(0)
+  const liveRef = useRef(true)
+
+  const poll = useCallback(async () => {
+    try {
+      const { announcements } = await api.announcements.list({
+        since: lastIdRef.current,
+      })
+      if (!liveRef.current) return
+      if (announcements.length > 0) {
+        const maxId = Math.max(...announcements.map((a) => a.id))
+        lastIdRef.current = maxId
+        setQueue((prev) => [...prev, ...announcements])
+      }
+    } catch {
+      // silent — network hiccups shouldn't break the waiter flow
+    }
+  }, [api])
+
+  useEffect(() => {
+    liveRef.current = true
+    void poll()
+    const timer = setInterval(() => void poll(), POLL_INTERVAL_MS)
+    return () => {
+      liveRef.current = false
+      clearInterval(timer)
+    }
+  }, [poll])
+
+  function dismiss() {
+    setQueue((prev) => prev.slice(1))
+  }
+
+  const current = queue[0]
+  if (!current) return null
+
+  const severityClass =
+    current.severity === 'urgent'
+      ? 'ann-modal--urgent'
+      : current.severity === 'warning'
+        ? 'ann-modal--warning'
+        : 'ann-modal--info'
+
+  const severityLabel =
+    current.severity === 'urgent'
+      ? 'Dringend'
+      : current.severity === 'warning'
+        ? 'Warnung'
+        : 'Info'
+
+  return (
+    <div className="ann-backdrop">
+      <div className={`ann-modal ${severityClass}`}>
+        <div className="ann-modal__header">
+          <span className="ann-modal__badge">{severityLabel}</span>
+          {queue.length > 1 && (
+            <span className="ann-modal__count">
+              +{queue.length - 1} weitere
+            </span>
+          )}
+        </div>
+        <div className="ann-modal__body">
+          <p className="ann-modal__message">{current.message}</p>
+          <p className="ann-modal__meta">
+            {current.createdBy} &middot;{' '}
+            {new Date(current.createdAt).toLocaleTimeString('de-DE', {
+              hour: '2-digit',
+              minute: '2-digit',
+            })}
+          </p>
+        </div>
+        <div className="ann-modal__footer">
+          <button
+            type="button"
+            className="btn-primary ann-modal__ok"
+            onClick={dismiss}
+          >
+            OK
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/waiter-web/src/components/Layout.tsx
+++ b/apps/waiter-web/src/components/Layout.tsx
@@ -1,5 +1,6 @@
 import { NavLink, Outlet } from 'react-router-dom'
 import { useAuth } from '@serva/auth-context'
+import { AnnouncementOverlay } from './AnnouncementOverlay'
 
 export function Layout() {
   const { eventId, user, logout } = useAuth()
@@ -33,6 +34,8 @@ export function Layout() {
           Meine Bestellungen
         </NavLink>
       </nav>
+
+      <AnnouncementOverlay />
     </div>
   )
 }

--- a/apps/waiter-web/src/index.css
+++ b/apps/waiter-web/src/index.css
@@ -2691,3 +2691,99 @@ body {
 .sr-dialog__add {
   border-radius: 10px;
 }
+
+/* ─── Announcement overlay ──────────────────────────────────── */
+.ann-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 100;
+  background: rgba(0, 0, 0, 0.6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 16px;
+}
+
+.ann-modal {
+  width: 100%;
+  max-width: 380px;
+  background: var(--color-bg);
+  border-radius: var(--radius);
+  border: 2px solid var(--color-border);
+  overflow: hidden;
+}
+
+.ann-modal--info {
+  border-color: var(--color-accent);
+}
+
+.ann-modal--warning {
+  border-color: #e6a700;
+}
+
+.ann-modal--urgent {
+  border-color: #d63031;
+}
+
+.ann-modal__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.ann-modal__badge {
+  font-size: 12px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  padding: 2px 8px;
+  border-radius: 4px;
+  color: #fff;
+}
+
+.ann-modal--info .ann-modal__badge {
+  background: var(--color-accent);
+}
+
+.ann-modal--warning .ann-modal__badge {
+  background: #e6a700;
+}
+
+.ann-modal--urgent .ann-modal__badge {
+  background: #d63031;
+}
+
+.ann-modal__count {
+  font-size: 12px;
+  color: var(--color-text-muted);
+}
+
+.ann-modal__body {
+  padding: 16px;
+}
+
+.ann-modal__message {
+  margin: 0;
+  font-size: 16px;
+  line-height: 1.5;
+  word-break: break-word;
+}
+
+.ann-modal__meta {
+  margin: 8px 0 0;
+  font-size: 12px;
+  color: var(--color-text-muted);
+}
+
+.ann-modal__footer {
+  padding: 0 16px 16px;
+}
+
+.ann-modal__ok {
+  width: 100%;
+  padding: 12px;
+  font-size: 16px;
+  border-radius: 10px;
+}

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -1,5 +1,9 @@
 import { HttpTransport } from "./http.js";
 import { createAdminEventsClient, type AdminEventsClient } from "./routes/admin-events.js";
+import {
+  createAnnouncementsClient,
+  type AnnouncementsClient,
+} from "./routes/announcements.js";
 import { createAuthClient, type AuthClient } from "./routes/auth.js";
 import { createConfigClient, type ConfigClient } from "./routes/config.js";
 import { createLogsClient, type LogsClient } from "./routes/logs.js";
@@ -20,6 +24,7 @@ import { createUsersClient, type UsersClient } from "./routes/users.js";
 
 export type {
   AdminEventsClient,
+  AnnouncementsClient,
   AuthClient,
   ConfigClient,
   LogsClient,
@@ -58,6 +63,7 @@ export interface ApiClientOptions {
 }
 
 export interface ServaApiClient {
+  announcements: AnnouncementsClient;
   auth: AuthClient;
   tables: TablesClient;
   menu: MenuClient;
@@ -75,6 +81,7 @@ export function createApiClient(opts: ApiClientOptions): ServaApiClient {
   const http = new HttpTransport(opts);
 
   return {
+    announcements: createAnnouncementsClient(http),
     auth: createAuthClient(http),
     tables: createTablesClient(http),
     menu: createMenuClient(http),

--- a/packages/api-client/src/routes/announcements.ts
+++ b/packages/api-client/src/routes/announcements.ts
@@ -1,0 +1,29 @@
+import {
+  AnnouncementCreateRequestSchema,
+  AnnouncementCreateResponseSchema,
+  AnnouncementsResponseSchema,
+  type AnnouncementCreateRequest,
+  type AnnouncementCreateResponse,
+  type AnnouncementsQuery,
+  type AnnouncementsResponse,
+} from "@serva/shared-types";
+import type { HttpTransport } from "../http.js";
+
+export interface AnnouncementsClient {
+  list(query?: AnnouncementsQuery): Promise<AnnouncementsResponse>;
+  create(body: AnnouncementCreateRequest): Promise<AnnouncementCreateResponse>;
+}
+
+export function createAnnouncementsClient(http: HttpTransport): AnnouncementsClient {
+  return {
+    list: (query) =>
+      http.get(AnnouncementsResponseSchema, "/announcements", query),
+
+    create: (body) =>
+      http.post(
+        AnnouncementCreateResponseSchema,
+        "/announcements",
+        AnnouncementCreateRequestSchema.parse(body),
+      ),
+  };
+}

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -993,6 +993,59 @@ export const LogsResponseSchema = z
   .strict();
 export type LogsResponse = z.infer<typeof LogsResponseSchema>;
 
+// ─── Announcements ─────────────────────────────────────────────────────────
+
+export const AnnouncementSeveritySchema = z.enum(["info", "warning", "urgent"]);
+export type AnnouncementSeverity = z.infer<typeof AnnouncementSeveritySchema>;
+
+export const AnnouncementDtoSchema = z
+  .object({
+    id: positiveInt,
+    message: nonEmptyString,
+    severity: AnnouncementSeveritySchema,
+    createdAt: z.string().datetime(),
+    createdBy: nonEmptyString,
+  })
+  .strict();
+export type AnnouncementDto = z.infer<typeof AnnouncementDtoSchema>;
+
+export const AnnouncementCreateRequestSchema = z
+  .object({
+    message: nonEmptyString,
+    severity: AnnouncementSeveritySchema.optional(),
+  })
+  .strict();
+export type AnnouncementCreateRequest = z.infer<typeof AnnouncementCreateRequestSchema>;
+
+export const AnnouncementCreateResponseSchema = AnnouncementDtoSchema;
+export type AnnouncementCreateResponse = AnnouncementDto;
+
+export const AnnouncementsQuerySchema = z
+  .object({
+    since: z.coerce
+      .number()
+      .int()
+      .nonnegative()
+      .optional()
+      .describe("Only return announcements with id > since. Example: ?since=5"),
+  })
+  .strict();
+export type AnnouncementsQuery = z.infer<typeof AnnouncementsQuerySchema>;
+
+export const AnnouncementsResponseSchema = z
+  .object({
+    announcements: z.array(AnnouncementDtoSchema),
+  })
+  .strict();
+export type AnnouncementsResponse = z.infer<typeof AnnouncementsResponseSchema>;
+
+export const AnnouncementParamsSchema = z
+  .object({
+    announcementId: z.coerce.number().int().positive(),
+  })
+  .strict();
+export type AnnouncementParams = z.infer<typeof AnnouncementParamsSchema>;
+
 export const ApiErrorEnvelopeSchema = z
   .object({
     error: z


### PR DESCRIPTION
## Summary
- Add full-stack announcement system: API endpoints (GET/POST /announcements), admin-desktop "Neue Ansage" button on Logs page, waiter-web modal overlay with 5s polling
- Auto-create low-stock/empty announcements when stock updates drop below threshold (configurable via stockLowThreshold config key, default 5)
- Announcements logged via Pino for the "also logged" requirement

Closes #94

## Test plan
- [ ] Admin creates announcement from Logs page, waiter sees modal within 5s
- [ ] Dismiss announcement via OK, next queued announcement shown (if any)
- [ ] Severity levels (Info/Warnung/Dringend) display with correct badge color
- [ ] Update stock item to quantity below threshold, auto "warning" announcement created
- [ ] Update stock item to 0, auto "urgent" announcement created
- [ ] Announcement creation appears in API logs
- [ ] GET /announcements?since=id returns only newer entries (polling)

Generated with [Claude Code](https://claude.com/claude-code)
