### PR TITLE
Serva-99: hide weights, fix table QR codes

### DIFF
--- a/apps/admin-desktop/src/App.css
+++ b/apps/admin-desktop/src/App.css
@@ -1028,7 +1028,6 @@ html, body, #root {
   grid-template-columns:
     36px          /* reorder buttons */
     1fr           /* name */
-    96px          /* weight */
     100px         /* status */
     120px;        /* actions */
   align-items: center;
@@ -1059,7 +1058,6 @@ html, body, #root {
   gap: 2px;
 }
 .tables-col-name    { font-weight: 500; font-size: 13px; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.tables-col-weight  { font-size: 13px; color: var(--color-muted); text-align: right; }
 .tables-col-status  { display: flex; align-items: center; }
 .tables-col-actions { display: flex; align-items: center; gap: 4px; justify-content: flex-end; }
 
@@ -1721,11 +1719,6 @@ html, body, #root {
   max-width: 160px;
   overflow: hidden;
   text-overflow: ellipsis;
-}
-
-.menu-item-weight {
-  font-size: 11px;
-  color: var(--color-muted);
 }
 
 .menu-item-row__right {

--- a/apps/admin-desktop/src/pages/MenuPage.tsx
+++ b/apps/admin-desktop/src/pages/MenuPage.tsx
@@ -23,18 +23,16 @@ function formatPrice(price: number): string {
 interface CatForm {
   name: string;
   description: string;
-  weight: string;
   isLocked: boolean;
   printerId: string;
   orderDisplayId: string;
 }
 
 function defaultCatForm(cat?: MenuCategoryDto): CatForm {
-  if (!cat) return { name: "", description: "", weight: "", isLocked: false, printerId: "", orderDisplayId: "" };
+  if (!cat) return { name: "", description: "", isLocked: false, printerId: "", orderDisplayId: "" };
   return {
     name: cat.name,
     description: cat.description,
-    weight: String(cat.weight),
     isLocked: cat.isLocked,
     printerId: cat.printerId != null ? String(cat.printerId) : "",
     orderDisplayId: cat.orderDisplayId != null ? String(cat.orderDisplayId) : "",
@@ -49,7 +47,6 @@ interface ItemForm {
   name: string;
   description: string;
   price: string;
-  weight: string;
   isLocked: boolean;
   menuCategoryId: string;
 }
@@ -60,7 +57,6 @@ function defaultItemForm(item?: MenuItemDto, defaultCatId?: number): ItemForm {
       name: "",
       description: "",
       price: "",
-      weight: "",
       isLocked: false,
       menuCategoryId: defaultCatId != null ? String(defaultCatId) : "",
     };
@@ -69,7 +65,6 @@ function defaultItemForm(item?: MenuItemDto, defaultCatId?: number): ItemForm {
     name: item.name,
     description: item.description,
     price: String(item.price),
-    weight: String(item.weight),
     isLocked: item.isLocked,
     menuCategoryId: String(item.menuCategoryId),
   };
@@ -120,20 +115,13 @@ function CategoryModal({ editing, printers, onClose, onSave, saving, error }: Ca
             <textarea id="cat-desc" className="form-input" style={{ resize: "vertical", minHeight: 64 }}
               value={form.description} onChange={(e) => set("description", e.target.value)} maxLength={500} />
           </div>
-          <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 12 }}>
-            <div className="form-group">
-              <label className="form-label" htmlFor="cat-weight">Gewichtung</label>
-              <input id="cat-weight" className="form-input" type="number"
-                value={form.weight} onChange={(e) => set("weight", e.target.value)} placeholder="0" />
-            </div>
-            <div className="form-group cat-checkbox-group">
-              <label className="form-label">Status</label>
-              <label className="cat-checkbox-label" htmlFor="cat-locked">
-                <input id="cat-locked" type="checkbox" checked={form.isLocked}
-                  onChange={(e) => set("isLocked", e.target.checked)} />
-                Gesperrt
-              </label>
-            </div>
+          <div className="form-group cat-checkbox-group">
+            <label className="form-label">Status</label>
+            <label className="cat-checkbox-label" htmlFor="cat-locked">
+              <input id="cat-locked" type="checkbox" checked={form.isLocked}
+                onChange={(e) => set("isLocked", e.target.checked)} />
+              Gesperrt
+            </label>
           </div>
           <div className="form-group">
             <label className="form-label" htmlFor="cat-printer">Drucker</label>
@@ -234,17 +222,10 @@ function ItemModal({ editing, categories, defaultCatId, onClose, onSave, saving,
             <textarea id="item-desc" className="form-input" style={{ resize: "vertical", minHeight: 60 }}
               value={form.description} onChange={(e) => set("description", e.target.value)} maxLength={500} />
           </div>
-          <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 12 }}>
-            <div className="form-group">
-              <label className="form-label" htmlFor="item-price">Preis (€) <span className="required-star">*</span></label>
-              <input id="item-price" className="form-input" type="number" min={0} step="0.01"
-                value={form.price} onChange={(e) => set("price", e.target.value)} placeholder="0,00" required />
-            </div>
-            <div className="form-group">
-              <label className="form-label" htmlFor="item-weight">Gewichtung</label>
-              <input id="item-weight" className="form-input" type="number"
-                value={form.weight} onChange={(e) => set("weight", e.target.value)} placeholder="0" />
-            </div>
+          <div className="form-group">
+            <label className="form-label" htmlFor="item-price">Preis (€) <span className="required-star">*</span></label>
+            <input id="item-price" className="form-input" type="number" min={0} step="0.01"
+              value={form.price} onChange={(e) => set("price", e.target.value)} placeholder="0,00" required />
           </div>
           <div className="form-group">
             <label className="form-label" htmlFor="item-cat">Kategorie <span className="required-star">*</span></label>
@@ -414,7 +395,6 @@ export function MenuPage() {
         const body = {
           name: form.name.trim(),
           ...(form.description.trim() && { description: form.description.trim() }),
-          ...(form.weight !== "" && { weight: parseInt(form.weight, 10) }),
           ...(form.isLocked && { isLocked: true }),
           ...(form.printerId !== "" && { printerId: parseInt(form.printerId, 10) }),
           ...(form.orderDisplayId !== "" && { orderDisplayId: parseInt(form.orderDisplayId, 10) }),
@@ -428,7 +408,6 @@ export function MenuPage() {
           name: form.name.trim(),
           description: form.description.trim(),
           isLocked: form.isLocked,
-          ...(form.weight !== "" && { weight: parseInt(form.weight, 10) }),
           ...(form.printerId !== "" && { printerId: parseInt(form.printerId, 10) }),
           ...(form.orderDisplayId !== "" && { orderDisplayId: parseInt(form.orderDisplayId, 10) }),
         };
@@ -500,6 +479,9 @@ export function MenuPage() {
     const swapIdx = idx + direction;
     if (swapIdx < 0 || swapIdx >= visibleItems.length) return;
 
+    // Switch to custom-order view so the move is visible and not re-sorted away by name
+    setItemSortByWeight(true);
+
     // Reassign weights across the whole visible list so they stay consistent
     const reordered = [...visibleItems];
     [reordered[idx], reordered[swapIdx]] = [reordered[swapIdx], reordered[idx]];
@@ -538,7 +520,6 @@ export function MenuPage() {
           price: parseFloat(form.price),
           menuCategoryId: parseInt(form.menuCategoryId, 10),
           ...(form.description.trim() && { description: form.description.trim() }),
-          ...(form.weight !== "" && { weight: parseInt(form.weight, 10) }),
           ...(form.isLocked && { isLocked: true }),
         };
         const created = await api.menu.createItem(body);
@@ -550,7 +531,6 @@ export function MenuPage() {
           price: parseFloat(form.price),
           isLocked: form.isLocked,
           menuCategoryId: parseInt(form.menuCategoryId, 10),
-          ...(form.weight !== "" && { weight: parseInt(form.weight, 10) }),
         });
         setAllItems((prev) => prev.map((i) => (i.id === updated.id ? updated : i)));
       }
@@ -750,7 +730,7 @@ export function MenuPage() {
                 <button
                   className={`menu-sort-btn${itemSortByWeight ? " menu-sort-btn--active" : ""}`}
                   onClick={() => setItemSortByWeight(true)}
-                >Gewichtung</button>
+                >Reihenfolge</button>
               </div>
               <button
                 className="btn-primary"
@@ -807,8 +787,8 @@ export function MenuPage() {
                     key={item.id}
                     className={`menu-item-row${item.isLocked ? " menu-item-row--locked" : ""}`}
                   >
-                    {/* Reorder buttons — visible only when sorting by weight in a single category */}
-                    {itemSortByWeight && selectedCatId !== "all" && (
+                    {/* Reorder buttons — available within a single category */}
+                    {selectedCatId !== "all" && (
                       <div className="menu-item-row__reorder">
                         <button
                           className="menu-reorder-btn"
@@ -836,12 +816,11 @@ export function MenuPage() {
                       {item.description && (
                         <div className="menu-item-row__desc">{item.description}</div>
                       )}
-                      <div className="menu-item-row__meta">
-                        {selectedCatId === "all" && (
+                      {selectedCatId === "all" && (
+                        <div className="menu-item-row__meta">
                           <span className="menu-item-cat-pill">{categoryName(item.menuCategoryId)}</span>
-                        )}
-                        <span className="menu-item-weight">Gewicht: {item.weight}</span>
-                      </div>
+                        </div>
+                      )}
                     </div>
 
                     {/* Price + status */}

--- a/apps/admin-desktop/src/pages/TablesPage.tsx
+++ b/apps/admin-desktop/src/pages/TablesPage.tsx
@@ -13,7 +13,6 @@ type LoadState =
 
 interface SingleFormState {
   name: string;
-  weight: string;
   isLocked: boolean;
 }
 
@@ -26,11 +25,10 @@ interface BulkFormState {
 
 function defaultSingleForm(table?: TableDto): SingleFormState {
   if (!table) {
-    return { name: "", weight: "", isLocked: false };
+    return { name: "", isLocked: false };
   }
   return {
     name: table.name,
-    weight: String(table.weight),
     isLocked: table.isLocked,
   };
 }
@@ -122,8 +120,7 @@ function SingleTableModal({
     setForm((prev) => ({ ...prev, [key]: value }));
   }
 
-  const weightValid = form.weight === "" || /^-?\d+$/.test(form.weight);
-  const canSubmit = form.name.trim() !== "" && weightValid;
+  const canSubmit = form.name.trim() !== "";
 
   return (
     <div
@@ -165,23 +162,6 @@ function SingleTableModal({
               maxLength={100}
               placeholder="z. B. A1"
             />
-          </div>
-
-          <div className="form-group">
-            <label className="form-label" htmlFor="table-weight">
-              Gewichtung
-            </label>
-            <input
-              id="table-weight"
-              className="form-input"
-              type="number"
-              value={form.weight}
-              onChange={(e) => set("weight", e.target.value)}
-              placeholder="0"
-            />
-            <span className="muted" style={{ fontSize: 11, marginTop: 4, display: "block" }}>
-              Niedrigere Werte erscheinen zuerst.
-            </span>
           </div>
 
           <div className="form-group cat-checkbox-group">
@@ -401,6 +381,7 @@ function QrPreviewModal({ table, onClose }: QrPreviewModalProps) {
   const [svgContent, setSvgContent] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [downloading, setDownloading] = useState(false);
 
   useEffect(() => {
     api.tables
@@ -414,6 +395,26 @@ function QrPreviewModal({ table, onClose }: QrPreviewModalProps) {
         setLoading(false);
       });
   }, [api, table.id]);
+
+  async function handleDownloadPdf() {
+    setDownloading(true);
+    setError(null);
+    try {
+      const blob = await api.tables.getTableQrPdf(table.id);
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = `tisch-${table.name}-qr.pdf`;
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      URL.revokeObjectURL(url);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Fehler beim PDF-Export.");
+    } finally {
+      setDownloading(false);
+    }
+  }
 
   return (
     <div
@@ -435,16 +436,27 @@ function QrPreviewModal({ table, onClose }: QrPreviewModalProps) {
         )}
         {error && <p className="form-error">{error}</p>}
         {svgContent && (
-          <div
-            style={{ display: "flex", justifyContent: "center", margin: "16px 0" }}
-            // SVG string comes from our own API — safe to render inline
-            dangerouslySetInnerHTML={{ __html: svgContent }}
-          />
+          <div style={{ display: "flex", justifyContent: "center", margin: "16px 0" }}>
+            <img
+              src={`data:image/svg+xml,${encodeURIComponent(svgContent)}`}
+              alt={`QR-Code Tisch ${table.name}`}
+              width={280}
+              height={280}
+            />
+          </div>
         )}
 
         <div className="modal-footer">
           <button type="button" className="btn-secondary" onClick={onClose}>
             Schließen
+          </button>
+          <button
+            type="button"
+            className="btn-primary modal-submit"
+            onClick={handleDownloadPdf}
+            disabled={loading || downloading}
+          >
+            {downloading ? "Wird exportiert…" : "PDF herunterladen"}
           </button>
         </div>
       </div>
@@ -512,14 +524,12 @@ export function TablesPage() {
       if (editTarget === "new") {
         const created = await api.tables.create({
           name: form.name.trim(),
-          ...(form.weight !== "" && { weight: parseInt(form.weight, 10) }),
           ...(form.isLocked && { isLocked: true }),
         });
         setTables((prev) => sortTables([...prev, created]));
       } else if (editTarget) {
         const updated = await api.tables.update(editTarget.id, {
           name: form.name.trim(),
-          ...(form.weight !== "" && { weight: parseInt(form.weight, 10) }),
           isLocked: form.isLocked,
         });
         setTables((prev) =>
@@ -722,7 +732,6 @@ export function TablesPage() {
           <div className="tables-row tables-row--header">
             <span className="tables-col-handle" />
             <span className="tables-col-name">Name</span>
-            <span className="tables-col-weight">Gewicht</span>
             <span className="tables-col-status">Status</span>
             <span className="tables-col-actions" />
           </div>
@@ -748,7 +757,6 @@ export function TablesPage() {
                 >▼</button>
               </span>
               <span className="tables-col-name">{table.name}</span>
-              <span className="tables-col-weight">{table.weight}</span>
               <span className="tables-col-status">
                 {table.isLocked ? (
                   <span className="badge-locked">Gesperrt</span>

--- a/apps/api/src/routes/tables.ts
+++ b/apps/api/src/routes/tables.ts
@@ -40,26 +40,14 @@ const TablesQrPdfQuerySchema = z
 
 type TablesQrPdfQuery = z.infer<typeof TablesQrPdfQuerySchema>;
 
-function escapeXml(value: string) {
-  return value
-    .replaceAll("&", "&amp;")
-    .replaceAll("<", "&lt;")
-    .replaceAll(">", "&gt;")
-    .replaceAll('"', "&quot;")
-    .replaceAll("'", "&apos;");
-}
-
 function buildTableQrSvg(input: { id: number; name: string }) {
-  const text = `${input.name} (#${input.id})`;
-  return `<?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="320" height="320" viewBox="0 0 320 320">
-  <rect x="0" y="0" width="320" height="320" fill="#ffffff" />
-  <rect x="20" y="20" width="280" height="280" fill="#000000" />
-  <rect x="40" y="40" width="240" height="240" fill="#ffffff" />
-  <text x="160" y="160" text-anchor="middle" dominant-baseline="middle" font-family="Arial, sans-serif" font-size="16" fill="#000000">${escapeXml(
-    text
-  )}</text>
-</svg>`;
+  const payload = JSON.stringify({ tableId: input.id, tableName: input.name });
+  return QRCode.toString(payload, {
+    type: "svg",
+    errorCorrectionLevel: "H",
+    margin: 2,
+    width: 320,
+  });
 }
 
 function fitTextSize(input: {
@@ -432,8 +420,43 @@ export function registerTableRoutes(app: FastifyInstance) {
     },
     async (request, reply) => {
       const table = tableStore.getTable(request.params.tableId);
-      const svg = buildTableQrSvg({ id: table.id, name: table.name });
+      const svg = await buildTableQrSvg({ id: table.id, name: table.name });
       return reply.type("image/svg+xml").send(svg);
+    }
+  );
+
+  app.get<{ Params: TableParams }>(
+    "/tables/:tableId/qr.pdf",
+    {
+      config: {
+        requiresRole: "admin",
+        requiresActiveEvent: true,
+      },
+      schema: {
+        tags: ["tables"],
+        operationId: "tablesQrExportPdfSingle",
+        summary: "QR-PDF fuer einen einzelnen Tisch exportieren",
+        description: "Erzeugt eine PDF mit dem QR-Code eines einzelnen Tisches.",
+        security: [{ bearerAuth: [] }],
+        params: TableParamsSchema,
+        response: {
+          200: TablesQrPdfResponseSchema,
+          401: ApiErrorEnvelopeSchema,
+          403: ApiErrorEnvelopeSchema,
+          404: ApiErrorEnvelopeSchema,
+          409: ApiErrorEnvelopeSchema,
+        },
+      },
+    },
+    async (request, reply) => {
+      const table = tableStore.getTable(request.params.tableId);
+      const pdf = await buildTablesQrPdf([{ id: table.id, name: table.name }], {
+        layout: "single",
+      });
+      return reply
+        .header("Content-Disposition", `attachment; filename=table-${table.id}-qr.pdf`)
+        .type("application/pdf")
+        .send(pdf);
     }
   );
 

--- a/packages/api-client/src/routes/tables.ts
+++ b/packages/api-client/src/routes/tables.ts
@@ -27,6 +27,8 @@ export interface TablesClient {
   /** Returns a PDF containing QR codes for all tables.
    *  `layout`: `"single"` (1 table/page) or `"double"` (2 tables/page, default). */
   getQrPdf(layout?: "single" | "double"): Promise<Blob>;
+  /** Returns a single-page PDF with the QR code for one table. */
+  getTableQrPdf(tableId: number): Promise<Blob>;
 }
 
 export function createTablesClient(http: HttpTransport): TablesClient {
@@ -59,5 +61,8 @@ export function createTablesClient(http: HttpTransport): TablesClient {
 
     getQrPdf: (layout) =>
       http.getBlob("/tables/qr.pdf", layout ? { layout } : undefined),
+
+    getTableQrPdf: (tableId) =>
+      http.getBlob(`/tables/${tableId}/qr.pdf`),
   };
 }


### PR DESCRIPTION
## Summary
- Closes #99 — remove all "weight" (Gewicht/Gewichtung) labels, columns and form inputs from the menu and tables admin pages; weight is now used only internally for sorting and reordering.
- Make menu-item reorder arrows available whenever a single category is selected, and auto-switch to custom order when used (previously they were hidden behind the sort toggle).
- Fix per-table QR codes: the SVG endpoint now generates a real, scannable QR code (it previously drew a placeholder box).
- Add single-table QR PDF export (`GET /tables/:tableId/qr.pdf`, `getTableQrPdf` client method, and a "PDF herunterladen" button in the QR preview modal).
- Render the QR preview as an `<img>` data URL for reliable display in the webview.

## Test plan
- [x] `tsc --noEmit` passes for api, api-client, and admin-desktop
- [x] API tables QR routes return valid SVG (`image/svg+xml`) and PDFs
- [ ] Manually verify in the desktop app: QR shows in the modal, single-table PDF downloads, reorder arrows work, no weight text appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)