### PR TITLE
Serva-105 fix: waiter-web SPA reload + special-request billing/bon

### DIFF
--- a/apps/api/src/domain/printer-store.ts
+++ b/apps/api/src/domain/printer-store.ts
@@ -45,6 +45,26 @@ function formatTimeOnly(iso: string): string {
   return `${hh}:${mm}`;
 }
 
+// Splits the stored special-requests string back into its constituent requests.
+// The client joins requests with "; " and prefixes a count only when >1 unit
+// shares the same note (e.g. "2x ohne Zwiebeln; extra Käse"). A missing prefix
+// means a single unit.
+function parseSpecialRequests(raw: string): Array<{ qty: number; text: string }> {
+  if (!raw) return [];
+  const requests: Array<{ qty: number; text: string }> = [];
+  for (const part of raw.split("; ")) {
+    const trimmed = part.trim();
+    if (!trimmed) continue;
+    const match = /^(\d+)x (.+)$/.exec(trimmed);
+    if (match) {
+      requests.push({ qty: Number(match[1]), text: match[2] });
+    } else {
+      requests.push({ qty: 1, text: trimmed });
+    }
+  }
+  return requests;
+}
+
 export class PrinterStore {
   constructor(private readonly eventStore: EventStore) {}
 
@@ -534,18 +554,26 @@ export class PrinterStore {
     printer.drawLine();
 
     for (const item of items) {
-      if (item.quantity > 0) {
+      // Special-request units print on their own line so the kitchen sees
+      // exactly how many of the item are modified. The client encodes each
+      // request as "[Nx ]text" joined by "; " (see waiter-web toOrderItems),
+      // and `quantity` already includes those units — so the plain (un-noted)
+      // count is the total minus the special-request units.
+      const requests = parseSpecialRequests(item.specialRequests);
+      const specialUnits = requests.reduce((sum, r) => sum + r.qty, 0);
+      const plainQty = item.quantity - specialUnits;
+
+      if (plainQty > 0) {
         printer.setTextQuadArea();
-        printer.println(`${item.quantity}x ${item.menuItemName}`);
+        printer.println(`${plainQty}x ${item.menuItemName}`);
         printer.setTextNormal();
       }
-      if (item.specialRequests) {
-        for (const sr of item.specialRequests.split("; ")) {
-          if (!sr) continue;
-          printer.setTextQuadArea();
-          printer.println(`*${sr}`);
-          printer.setTextNormal();
-        }
+
+      for (const request of requests) {
+        printer.setTextQuadArea();
+        printer.println(`${request.qty}x ${item.menuItemName}`);
+        printer.println(` *${request.text}`);
+        printer.setTextNormal();
       }
     }
 

--- a/apps/waiter-web/e2e/login.spec.ts
+++ b/apps/waiter-web/e2e/login.spec.ts
@@ -1,7 +1,7 @@
 import { expect, test } from "@playwright/test";
 
 test("login page renders the waiter form", async ({ page }) => {
-  await page.goto("/login");
+  await page.goto("/waiter/login");
 
   await expect(page.getByRole("heading", { name: "Serva" })).toBeVisible();
   await expect(page.getByLabel("Benutzername")).toBeVisible();

--- a/apps/waiter-web/src/App.tsx
+++ b/apps/waiter-web/src/App.tsx
@@ -115,7 +115,7 @@ function AppInner() {
 
 export default function App() {
   return (
-    <BrowserRouter>
+    <BrowserRouter basename={import.meta.env.BASE_URL.replace(/\/$/, '')}>
       {/* CartProvider wraps AppInner so clearCart is available before AuthProvider mounts */}
       <CartProvider>
         <AppInner />

--- a/apps/waiter-web/src/contexts/CartContext.tsx
+++ b/apps/waiter-web/src/contexts/CartContext.tsx
@@ -28,6 +28,17 @@ export interface CartLine {
   paidQty: number
 }
 
+/**
+ * Total billable units for a line: the plain quantity plus every special
+ * request's quantity. Each special-request unit is a unit of the item (with a
+ * note) charged at the item's price.
+ */
+export function lineUnits(line: CartLine): number {
+  return (
+    line.qty + line.specialRequests.reduce((sum, sr) => sum + sr.qty, 0)
+  )
+}
+
 interface CartState {
   tableId: number | null
   lines: Record<number, CartLine>
@@ -36,7 +47,7 @@ interface CartState {
 interface CartContextValue {
   tableId: number | null
   lines: Record<number, CartLine>
-  /** Total item count across all lines (sum of quantities). */
+  /** Total billable units across all lines (item quantities + special-request quantities). */
   count: number
   /** Grand total in currency units. */
   total: number
@@ -261,7 +272,7 @@ export function CartProvider({ children }: { children: ReactNode }) {
         const itemId = Number(key)
         const line = updatedLines[itemId]
         if (!line || units <= 0) continue
-        const newPaid = Math.min(line.paidQty + units, line.qty)
+        const newPaid = Math.min(line.paidQty + units, lineUnits(line))
         updatedLines[itemId] = { ...line, paidQty: newPaid }
       }
       return { ...prev, lines: updatedLines }
@@ -273,10 +284,11 @@ export function CartProvider({ children }: { children: ReactNode }) {
   const { count, total, regularCount, extraCount } = useMemo(() => {
     let c = 0, t = 0, r = 0, e = 0
     for (const line of Object.values(cart.lines)) {
-      c += line.qty
-      t += line.qty * line.item.price
-      if (line.isExtra) e += line.qty
-      else r += line.qty
+      const units = lineUnits(line)
+      c += units
+      t += units * line.item.price
+      if (line.isExtra) e += units
+      else r += units
     }
     return { count: c, total: t, regularCount: r, extraCount: e }
   }, [cart.lines])

--- a/apps/waiter-web/src/main.tsx
+++ b/apps/waiter-web/src/main.tsx
@@ -9,11 +9,11 @@ createRoot(document.getElementById('root')!).render(
   </StrictMode>,
 )
 
-// Service worker — only in production. In dev, base is `/` and a SW at root
-// scope would intercept Vite's HMR and the API proxy. In prod, base is
-// `/waiter/`, so `${BASE_URL}sw.js` is `/waiter/sw.js` with scope `/waiter/`
-// — API requests under `/orders`, `/auth`, etc. are outside that scope and
-// the SW never sees them, which is exactly what we want.
+// Service worker — only in production. Registering it in dev would interfere
+// with Vite's HMR. In prod, base is `/waiter/`, so `${BASE_URL}sw.js` is
+// `/waiter/sw.js` with scope `/waiter/` — API requests under `/orders`,
+// `/auth`, etc. are outside that scope and the SW never sees them, which is
+// exactly what we want.
 if (import.meta.env.PROD && 'serviceWorker' in navigator) {
   window.addEventListener('load', () => {
     navigator.serviceWorker

--- a/apps/waiter-web/src/pages/OrderPage.tsx
+++ b/apps/waiter-web/src/pages/OrderPage.tsx
@@ -10,7 +10,7 @@ import {
 } from '@serva/api-client'
 import type { OrderPrintResultDto } from '@serva/shared-types'
 import { useApiClient } from '../hooks/useApiClient'
-import { useCart } from '../contexts/CartContext'
+import { useCart, lineUnits } from '../contexts/CartContext'
 import type { CartLine } from '../contexts/CartContext'
 
 // ---------------------------------------------------------------------------
@@ -60,7 +60,7 @@ function toOrderItems(lines: CartLine[]) {
         .trim()
       return {
         menuItemId: line.item.id,
-        quantity: line.qty,
+        quantity: lineUnits(line),
         ...(sr ? { specialRequests: sr } : {}),
       }
     })
@@ -358,7 +358,7 @@ export function OrderPage() {
       {regularLines.length > 0 && (
         <ul className="order-list" aria-label="Bestellung">
           {regularLines.map((line) => {
-            const openQty = line.qty - line.paidQty
+            const openQty = lineUnits(line) - line.paidQty
             const subQty = subBill[line.item.id] ?? 0
             return (
               <CartItemRow
@@ -412,7 +412,7 @@ export function OrderPage() {
             ) : (
               <ul className="order-list order-list--extra" aria-label="Extras">
                 {extraLines.map((line) => {
-                  const openQty = line.qty - line.paidQty
+                  const openQty = lineUnits(line) - line.paidQty
                   const subQty = subBill[line.item.id] ?? 0
                   return (
                     <CartItemRow
@@ -528,7 +528,8 @@ function CartItemRow({
   onSetSpecialRequestQty,
 }: CartItemRowProps) {
   const { item, qty, specialRequests, isExtra, paidQty } = line
-  const lineTotal = qty * item.price
+  const units = lineUnits(line)
+  const lineTotal = units * item.price
 
   return (
     <li className={[
@@ -615,7 +616,7 @@ function CartItemRow({
               {openQty} offen
             </span>
           )}
-          {openQty === 0 && qty > 0 && (
+          {openQty === 0 && units > 0 && (
             <span className="payment-badge payment-badge--done" aria-label="Vollstaendig bezahlt">
               &#10003; Bezahlt
             </span>

--- a/apps/waiter-web/vite.config.ts
+++ b/apps/waiter-web/vite.config.ts
@@ -1,12 +1,14 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 
-// In production the waiter PWA is served by the Fastify API at `/waiter/`.
-// Vite needs the matching `base` so emitted asset URLs resolve correctly.
-// Dev keeps `base = '/'` and proxies API calls to the API on :8787.
-export default defineConfig(({ command }) => ({
+// The waiter PWA lives under `/waiter/` in both dev and prod so its client
+// routes (`/waiter/tables`, `/waiter/orders`, …) never collide with the API
+// route paths (`/tables`, `/orders`, …). Without this, reloading a page like
+// `/tables` resolves to the API and shows the JSON response instead of the GUI.
+// API calls use root-absolute paths and are proxied to the API on :8787.
+export default defineConfig(() => ({
   plugins: [react()],
-  base: command === 'build' ? '/waiter/' : '/',
+  base: '/waiter/',
   server: {
     proxy: {
       '/auth': 'http://localhost:8787',


### PR DESCRIPTION
## Summary
- Namespace the waiter PWA under `/waiter` so client routes (`/waiter/tables`, …) no longer collide with API route paths. Fixes #105: reloading a page like `/tables` showed the API JSON response instead of the GUI.
- Special requests now count as billable units of their item: cart total/count and the submitted quantity include special-request quantities.
- The kitchen bon splits plain and special-request units onto their own lines, printing the note beneath each special line.

## Test plan
- [ ] `pnpm --filter waiter-web build` passes; e2e login test passes (loads `/waiter/login`)
- [ ] Reload `/waiter/tables` (and the QR deep-link `/waiter`) shows the GUI, not JSON
- [ ] Add an item via "+ Sonderwunsch" only — cart total and item count include it; submitted quantity is non-zero
- [ ] API `tsc` build + print test suite pass
- [ ] Bon for "2 plain + 1 ohne Zwiebeln" prints `2x Burger` / `1x Burger` / ` *ohne Zwiebeln`

🤖 Generated with [Claude Code](https://claude.com/claude-code)