### PR TITLE
Serva-103 docs: project README + docs/ guides + env examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,167 @@
 # Serva
-A Desktop App for Events. Manage Events, Serve Customers. Everything Local with your Laptop and your Phones
+
+**A local-first event hospitality platform.** Run it from a single laptop at your
+event — no cloud, no internet dependency, no monthly fees. The operator's laptop
+hosts the API and the apps; waiters take orders from their phones; the operator
+manages everything from a desktop admin app. All of it talks over your own local
+network.
+
+> Manage events, serve customers — everything local, with your laptop and your phones.
+
+---
+
+## How it works
+
+```
+                  Local Wi-Fi / LAN
+                          │
+   ┌──────────────────────┼────────────────────────┐
+   │                      │                        │
+┌──┴─────────────┐   ┌────┴────────┐       ┌───────┴────────┐
+│ Operator       │   │ Waiter      │       │ Waiter         │
+│ laptop         │   │ phone       │  ...  │ phone          │
+│                │   │ (browser)   │       │ (browser)      │
+│ • API (Fastify)│   │ waiter-web  │       │ waiter-web     │
+│ • admin-desktop│   │ PWA         │       │ PWA            │
+│ • waiter-web   │   └─────────────┘       └────────────────┘
+│   (served at   │
+│    /waiter/)   │
+└────────────────┘
+```
+
+- The **API** runs on the operator's laptop and owns all data (SQLite files on disk).
+- **waiter-web** is a phone PWA the API serves at `/waiter/`; waiters scan a table
+  QR code, browse the menu, and send orders straight to the kitchen printer.
+- **admin-desktop** is a Tauri desktop app the operator uses to create events,
+  manage the menu/tables/users, and watch incoming orders.
+
+Because everything is local, the venue keeps working even when the internet doesn't.
+
+---
+
+## Monorepo layout
+
+pnpm workspaces (`apps/*`, `packages/*`).
+
+| Workspace | Tech | Purpose |
+|---|---|---|
+| [`apps/api`](apps/api) | Fastify 5, TypeScript, better-sqlite3 | REST API, JWT auth, Swagger UI; serves the waiter PWA |
+| [`apps/admin-desktop`](apps/admin-desktop) | Tauri v2, React 19, Vite | Desktop admin app for the operator |
+| [`apps/waiter-web`](apps/waiter-web) | React 19, Vite (PWA) | Waiter ordering app for phones |
+| [`packages/shared-types`](packages/shared-types) | Zod 4, TypeScript | Single source of truth for all API contracts |
+| [`packages/api-client`](packages/api-client) | TypeScript | Typed HTTP client (framework-agnostic) |
+| [`packages/auth-context`](packages/auth-context) | React | `AuthProvider` / `useAuth` hook for the apps |
+
+---
+
+## Prerequisites
+
+- **Node.js 20.19+** (22 LTS recommended).
+- **pnpm 10** — the repo pins `pnpm@10.33.0`. The easiest way to get the right
+  version is Corepack: `corepack enable && corepack prepare pnpm@10.33.0 --activate`.
+- **Rust toolchain** — only needed to build/run `admin-desktop` (Tauri v2). See the
+  [Tauri prerequisites](https://v2.tauri.app/start/prerequisites/) for your OS
+  (on Windows you also need the WebView2 runtime and MSVC build tools). You do **not**
+  need Rust to run the API or the waiter PWA.
+
+---
+
+## Quick start
+
+```bash
+# 1. Install dependencies for every workspace
+pnpm install
+
+# 2. Build the shared packages (the apps import their compiled output)
+pnpm build
+
+# 3. Configure the API (see apps/api/.env.example)
+cp apps/api/.env.example apps/api/.env
+#   then edit apps/api/.env and set MASTER_PASSWORD and JWT_SECRET
+
+# 4. Run everything in dev mode (API + both frontends, in parallel)
+pnpm dev
+```
+
+What's now running:
+
+| Service | URL |
+|---|---|
+| API (HTTP) | http://localhost:8787 |
+| API Swagger UI | http://localhost:8787/documentation |
+| Waiter PWA (Vite dev) | http://localhost:5173/waiter/ |
+| Admin desktop | launches as a Tauri window (needs Rust) |
+
+> The shared packages (`shared-types`, `api-client`, `auth-context`) have no dev
+> server — they are compiled once by `pnpm build`. Re-run `pnpm build` (or build the
+> specific package) after changing a contract in `shared-types`.
+
+Want just the backend? `pnpm --filter @serva/shared-types build && pnpm --filter api dev`.
+
+New here? Read the **[Getting Started guide](docs/getting-started.md)** for a
+step-by-step walkthrough, including how to reach the apps from real phones.
+
+---
+
+## Using Serva (the happy path)
+
+Serva has three roles. A typical event runs like this:
+
+1. **Master** logs in (`MASTER_USERNAME` / `MASTER_PASSWORD` from `.env`) and creates
+   an event with an admin account and a waiter passcode, then **activates** it. Only
+   one event is active at a time.
+2. **Admin** logs in with the event's admin credentials and sets up the menu, tables
+   (printing QR codes), printers, and stock.
+3. **Waiters** open the waiter PWA on their phones, log in with their name + the event
+   passcode, scan a table's QR code, and send orders — which print on the assigned
+   kitchen printer.
+
+Full role/permission details and request examples are in the
+[API guide](docs/api.md) and [`apps/api/README.md`](apps/api/README.md).
+
+---
+
+## Accessing the apps from phones
+
+Phones connect to the operator laptop over the local network using the laptop's LAN
+IP (the API listens on `0.0.0.0`). The QR scanner needs a **secure context**, so for
+real phone use you should enable HTTPS:
+
+```bash
+pnpm --filter api gen-cert      # writes a self-signed cert to apps/api/tls/
+pnpm --filter waiter-web build  # build the PWA so the API can serve it
+pnpm --filter api dev           # now serving https://<laptop-ip>:8443/waiter/
+```
+
+Then point a phone browser at `https://<laptop-ip>:8443/waiter/` (accept the
+self-signed certificate warning once). See
+[Getting Started → phones & HTTPS](docs/getting-started.md#running-on-phones-https)
+for the details.
+
+---
+
+## Testing
+
+```bash
+pnpm --filter @serva/shared-types build   # required before API/client tests
+pnpm --filter api test                    # API: node:test, run serially
+pnpm --filter @serva/api-client test      # typed client tests
+pnpm --filter waiter-web test:e2e         # Playwright (boots API + Vite)
+```
+
+---
+
+## Documentation
+
+- [Getting Started](docs/getting-started.md) — install, run, run on phones, troubleshoot
+- [Architecture](docs/architecture.md) — system design, two-database model, auth roles
+- [API Guide](docs/api.md) — auth flows, endpoint reference, error model
+- [`docs/Planning`](docs/Planning) — design notes, diagrams, and milestone planning
+
+Each workspace also has its own README with details specific to that package.
+
+---
+
+## License
+
+[MIT](LICENSE) © 2026 Elias Pöschl

--- a/apps/admin-desktop/.env.example
+++ b/apps/admin-desktop/.env.example
@@ -1,0 +1,7 @@
+# Copy this file to `.env` and adjust as needed.
+#   cp apps/admin-desktop/.env.example apps/admin-desktop/.env
+# `.env` is git-ignored.
+
+# Base URL of the Serva API the desktop app talks to.
+# Point this at the operator laptop running `apps/api`.
+VITE_API_BASE_URL=http://localhost:8787

--- a/apps/admin-desktop/README.md
+++ b/apps/admin-desktop/README.md
@@ -1,7 +1,50 @@
-# Tauri + React + Typescript
+# admin-desktop
 
-This template should help get you started developing with Tauri, React and Typescript in Vite.
+The operator's desktop app for Serva, built with **Tauri v2** + React 19 + Vite. The
+operator uses it to create and activate events, manage the menu/tables/users/printers,
+and watch incoming orders. It talks to the Serva API through `@serva/api-client`.
 
-## Recommended IDE Setup
+See the repo [README](../../README.md) and [docs](../../docs) for the big picture.
 
-- [VS Code](https://code.visualstudio.com/) + [Tauri](https://marketplace.visualstudio.com/items?itemName=tauri-apps.tauri-vscode) + [rust-analyzer](https://marketplace.visualstudio.com/items?itemName=rust-lang.rust-analyzer)
+## Prerequisites
+
+In addition to the repo prerequisites, this app needs the **Rust toolchain** and the
+Tauri system dependencies — follow the
+[Tauri prerequisites](https://v2.tauri.app/start/prerequisites/) for your OS (on Windows:
+WebView2 runtime + MSVC C++ build tools).
+
+## Configure
+
+```bash
+cp .env.example .env     # set VITE_API_BASE_URL to the API origin (default http://localhost:8787)
+```
+
+## Develop
+
+```bash
+# from the repo root, once: build the shared packages this app imports
+pnpm build
+
+# desktop app (native window, hot reload)
+pnpm --filter appsadmin-desktop tauri dev
+
+# or just the web layer in a browser (no native shell)
+pnpm --filter appsadmin-desktop dev
+```
+
+> The workspace package name is `appsadmin-desktop` (used with `--filter`).
+
+## Build
+
+```bash
+pnpm --filter appsadmin-desktop tauri build      # production desktop bundle
+```
+
+From the repo root, `pnpm tauri:build` builds the shared packages + waiter PWA first,
+then the desktop bundle.
+
+## Test
+
+```bash
+pnpm --filter appsadmin-desktop test:e2e         # Playwright
+```

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -1,0 +1,23 @@
+# Copy this file to `.env` and fill in real values.
+#   cp apps/api/.env.example apps/api/.env
+# `.env` is git-ignored — never commit real secrets.
+
+# --- Required ---
+
+# Prisma connection string. Used by the Prisma CLI for migrations; the runtime
+# domain stores open per-event SQLite files directly.
+DATABASE_URL=file:./dev.db
+
+# Master account — the global operator who creates and activates events.
+MASTER_USERNAME=master
+MASTER_PASSWORD=change-me
+
+# Secret used to sign JWTs. Use a long random string.
+JWT_SECRET=change-me-to-a-long-random-string
+
+# --- Optional (defaults shown) ---
+
+# HOST=0.0.0.0
+# PORT=8787
+# HTTPS_PORT=8443
+# PRINTER_TEST_PRINT_TIMEOUT_MS=4000

--- a/apps/waiter-web/README.md
+++ b/apps/waiter-web/README.md
@@ -1,73 +1,48 @@
-# React + TypeScript + Vite
+# waiter-web
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+The waiter PWA for Serva — a phone-first React app waiters use to scan a table's QR
+code, browse the menu, and send orders to the kitchen. In production the Serva API
+serves this app's build output at `/waiter/`.
 
-Currently, two official plugins are available:
+See the repo [README](../../README.md) and [docs](../../docs) for the big picture.
 
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Oxc](https://oxc.rs)
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react-swc) uses [SWC](https://swc.rs/)
+## Develop
 
-## React Compiler
+```bash
+# from the repo root, once: build the shared packages this app imports
+pnpm build
 
-The React Compiler is not enabled on this template because of its impact on dev & build performances. To add it, see [this documentation](https://react.dev/learn/react-compiler/installation).
-
-## Expanding the ESLint configuration
-
-If you are developing a production application, we recommend updating the configuration to enable type-aware lint rules:
-
-```js
-export default defineConfig([
-  globalIgnores(['dist']),
-  {
-    files: ['**/*.{ts,tsx}'],
-    extends: [
-      // Other configs...
-
-      // Remove tseslint.configs.recommended and replace with this
-      tseslint.configs.recommendedTypeChecked,
-      // Alternatively, use this for stricter rules
-      tseslint.configs.strictTypeChecked,
-      // Optionally, add this for stylistic rules
-      tseslint.configs.stylisticTypeChecked,
-
-      // Other configs...
-    ],
-    languageOptions: {
-      parserOptions: {
-        project: ['./tsconfig.node.json', './tsconfig.app.json'],
-        tsconfigRootDir: import.meta.dirname,
-      },
-      // other options...
-    },
-  },
-])
+pnpm --filter waiter-web dev      # Vite dev server → http://localhost:5173/waiter/
 ```
 
-You can also install [eslint-plugin-react-x](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-x) and [eslint-plugin-react-dom](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-dom) for React-specific lint rules:
+The app is namespaced under `/waiter/` (Vite `base`), so its client routes never collide
+with API route paths. API calls use root-absolute paths (`/auth`, `/orders`, …) and are
+proxied to the API on `:8787` by `vite.config.ts`.
 
-```js
-// eslint.config.js
-import reactX from 'eslint-plugin-react-x'
-import reactDom from 'eslint-plugin-react-dom'
+Set `VITE_API_BASE_URL` to point at a non-default API origin (defaults to same-origin,
+which works with the dev proxy and with the production build served by the API).
 
-export default defineConfig([
-  globalIgnores(['dist']),
-  {
-    files: ['**/*.{ts,tsx}'],
-    extends: [
-      // Other configs...
-      // Enable lint rules for React
-      reactX.configs['recommended-typescript'],
-      // Enable lint rules for React DOM
-      reactDom.configs.recommended,
-    ],
-    languageOptions: {
-      parserOptions: {
-        project: ['./tsconfig.node.json', './tsconfig.app.json'],
-        tsconfigRootDir: import.meta.dirname,
-      },
-      // other options...
-    },
-  },
-])
+## Build & serve to phones
+
+```bash
+pnpm --filter waiter-web build    # outputs dist/ (base /waiter/)
 ```
+
+The API auto-detects `apps/waiter-web/dist` and serves it at `/waiter/`, with an
+`index.html` fallback for deep-link reloads. For phone use you'll want the API running
+over HTTPS (the camera/QR scanner needs a secure context) — see
+[docs/getting-started.md → Running on phones](../../docs/getting-started.md#running-on-phones-https).
+
+## Test & lint
+
+```bash
+pnpm --filter waiter-web test:e2e   # Playwright; boots the API + Vite automatically
+pnpm --filter waiter-web lint
+```
+
+## Layout
+
+- `src/pages/*` — Tables, Menu, Order, Orders, Login screens
+- `src/contexts/*` — cart state (`CartContext`) and API client wiring
+- `src/components/*` — shared UI (layout shell, error boundary)
+- `e2e/*` — Playwright specs

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,27 @@
+# Serva documentation
+
+Start at the [project README](../README.md) for the overview, then dive in here.
+
+## Guides
+
+- **[Getting Started](getting-started.md)** — install prerequisites, run the stack in
+  dev, reach the apps from real phones over HTTPS, and troubleshoot common issues.
+- **[Architecture](architecture.md)** — how the pieces fit together: the operator-laptop
+  model, the two-database design, the store pattern, route guards, and the
+  shared-types contract.
+- **[API Guide](api.md)** — authentication roles and flows, the endpoint reference, and
+  the error model. The live, always-accurate reference is the Swagger UI at
+  `/documentation` when the API is running.
+
+## Per-workspace docs
+
+- [`apps/api`](../apps/api/README.md) — backend, auth, event lifecycle, smoke test
+- [`apps/waiter-web`](../apps/waiter-web/README.md) — waiter PWA
+- [`apps/admin-desktop`](../apps/admin-desktop/README.md) — operator desktop app
+- [`packages/shared-types`](../packages/shared-types/README.md) — Zod schemas & types
+
+## Design & planning
+
+The [`Planning/`](Planning) folder holds the original design material — API endpoint
+notes, ER/class diagrams, MVVM notes, mindmaps, and the MVP milestone breakdown. It
+documents intent and history; the guides above describe the system as built.

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,211 @@
+# API Guide
+
+The Serva API is a Fastify REST service. The **authoritative, always-current reference**
+is the Swagger UI served by the running API:
+
+```
+http://localhost:8787/documentation        # (or https://<host>:8443/documentation)
+```
+
+This page summarizes the auth model, the typical flows, and the full endpoint list with
+the role each one requires.
+
+## Authentication
+
+All protected endpoints expect a **Bearer JWT**:
+
+```
+Authorization: Bearer <accessToken>
+```
+
+Tokens are obtained from the login endpoints below and expire after 1 hour. There are
+three roles:
+
+| Role | Login | Token claims | Can do |
+|---|---|---|---|
+| `master` | `POST /auth/master/login` (`MASTER_USERNAME`/`MASTER_PASSWORD`) | `role` | manage events under `/admin/events/*` |
+| `admin` | `POST /auth/admin/login` (event ID + admin credentials) | `role`, `eventId`, `username` | manage the active event it belongs to |
+| `waiter` | `POST /auth/login` (username + event passcode) | `role`, `eventId`, `username` | take orders for the active event |
+
+### Login examples
+
+```bash
+# Master
+curl -X POST http://localhost:8787/auth/master/login \
+  -H 'Content-Type: application/json' \
+  -d '{"username":"master","password":"<MASTER_PASSWORD>"}'
+
+# Waiter (event must be active; passcode is set by the admin)
+curl -X POST http://localhost:8787/auth/login \
+  -H 'Content-Type: application/json' \
+  -d '{"username":"anna","eventPasscode":"1234"}'
+
+# Authenticated request
+curl http://localhost:8787/auth/me -H "Authorization: Bearer $TOKEN"
+```
+
+PowerShell variants for the full master → admin → waiter flow are in
+[`apps/api/README.md`](../apps/api/README.md).
+
+## Typical flow
+
+1. **Master** creates and activates an event:
+   `POST /admin/events` → `POST /admin/events/{id}/activate`.
+2. **Admin** logs in and configures the event: create tables (`POST /tables`,
+   `POST /tables/bulk`), build the menu (`POST /menu/categories`, `POST /menu/items`),
+   register printers (`POST /printers`), set stock (`POST /stock/items`), print table QR
+   codes (`GET /tables/qr.pdf`).
+3. **Waiters** log in, read the menu and tables, and submit orders
+   (`POST /orders`), which can be printed to the assigned kitchen printer
+   (`POST /orders/{id}/print`).
+
+## Endpoint reference
+
+Legend — **Role**: who may call it. **Active event**: requires an active event (returns
+`409 NO_ACTIVE_EVENT` otherwise).
+
+### Auth
+
+| Method & path | Role | Active event |
+|---|---|---|
+| `POST /auth/master/login` | public | – |
+| `POST /auth/admin/login` | public | – |
+| `POST /auth/login` | public | yes |
+| `GET /auth/me` | any authenticated | – |
+
+### Events (master lifecycle)
+
+| Method & path | Role | Active event |
+|---|---|---|
+| `POST /admin/events` | master | – |
+| `GET /admin/events` | master | – |
+| `GET /admin/events/active` | master, admin | – |
+| `POST /admin/events/{eventId}/activate` | master | – |
+| `POST /admin/events/{eventId}/deactivate` | master | – |
+| `POST /admin/events/{eventId}/close` | master | – |
+| `DELETE /admin/events/{eventId}` | master | – |
+| `GET /admin/event-passcode` | admin | yes |
+| `PUT /admin/event-passcode` | admin | yes |
+
+### Menu
+
+| Method & path | Role | Active event |
+|---|---|---|
+| `GET /menu/categories` | waiter, admin | yes |
+| `GET /menu/items` | waiter, admin | yes |
+| `POST /menu/categories` | admin | yes |
+| `PATCH /menu/categories/{categoryId}` | admin | yes |
+| `DELETE /menu/categories/{categoryId}` | admin | yes |
+| `POST /menu/items` | admin | yes |
+| `PATCH /menu/items/{menuItemId}` | admin | yes |
+| `DELETE /menu/items/{menuItemId}` | admin | yes |
+
+### Tables
+
+| Method & path | Role | Active event |
+|---|---|---|
+| `GET /tables` | waiter, admin | yes |
+| `POST /tables` | admin | yes |
+| `POST /tables/bulk` | admin | yes |
+| `PATCH /tables/{tableId}` | admin | yes |
+| `GET /tables/{tableId}/qr` | admin | yes |
+| `GET /tables/{tableId}/qr.pdf` | admin | yes |
+| `GET /tables/qr.pdf` | admin | yes |
+
+`GET /tables/qr.pdf` accepts `layout=double` (default, 2 tables/page with a cut line) or
+`layout=single` (1 table/page).
+
+### Orders
+
+| Method & path | Role | Active event |
+|---|---|---|
+| `GET /orders` | admin, waiter | yes |
+| `POST /orders` | admin, waiter | yes |
+| `GET /orders/{orderId}` | admin, waiter | yes |
+| `POST /orders/{orderId}/print` | admin, waiter | yes |
+
+Waiters see/act on their own orders; admins see all. `POST /orders` body:
+`{ "tableId": 1, "items": [{ "menuItemId": 1, "quantity": 2, "specialRequests": "..." }] }`.
+
+### Printers
+
+| Method & path | Role | Active event |
+|---|---|---|
+| `GET /printers` | admin | yes |
+| `POST /printers` | admin | yes |
+| `GET /printers/{printerId}` | admin | yes |
+| `PATCH /printers/{printerId}` | admin | yes |
+| `DELETE /printers/{printerId}` | admin | yes |
+| `POST /printers/{printerId}/test-print` | admin | yes |
+
+`test-print` returns detailed `409` errors on connection problems
+(`PRINTER_CONNECTION_REFUSED`, `PRINTER_CONNECTION_TIMEOUT`, `PRINTER_HOST_UNREACHABLE`,
+`PRINTER_CONNECTION_FAILED`), each with `details.target` and a `details.hint`.
+
+### Stock
+
+| Method & path | Role | Active event |
+|---|---|---|
+| `GET /stock/items` | admin | yes |
+| `POST /stock/items` | admin | yes |
+| `PATCH /stock/items/{stockItemId}` | admin | yes |
+| `GET /menu/items/{menuItemId}/stock-requirements` | admin | yes |
+| `PUT /menu/items/{menuItemId}/stock-requirements` | admin | yes |
+
+### Users
+
+| Method & path | Role | Active event |
+|---|---|---|
+| `GET /users` | admin | yes |
+| `POST /users` | admin | yes |
+| `GET /users/{userId}` | admin | yes |
+| `PATCH /users/{userId}` | admin | yes |
+| `DELETE /users/{userId}` | admin | yes |
+
+### Order displays
+
+| Method & path | Role | Active event |
+|---|---|---|
+| `GET /order-displays` | admin | yes |
+| `POST /order-displays` | admin | yes |
+| `GET /order-displays/{orderDisplayId}` | admin | yes |
+| `PATCH /order-displays/{orderDisplayId}` | admin | yes |
+| `DELETE /order-displays/{orderDisplayId}` | admin | yes |
+
+### Config, announcements, logs, ops
+
+| Method & path | Role | Active event |
+|---|---|---|
+| `GET /config` | admin | yes |
+| `PATCH /config` | admin | yes |
+| `GET /announcements` | admin, waiter | yes |
+| `POST /announcements` | admin | yes |
+| `GET /logs` | master, admin | – |
+| `GET /host-info` | public | – |
+
+## Error model
+
+Errors use a consistent envelope:
+
+```json
+{ "error": { "code": "NO_ACTIVE_EVENT", "message": "…", "details": { } } }
+```
+
+Common status codes:
+
+| Status | Meaning |
+|---|---|
+| `400` | malformed request / bad input |
+| `401 UNAUTHORIZED` | missing, malformed, invalid, or expired token |
+| `403 FORBIDDEN` | valid token, but wrong role or wrong event binding |
+| `404` | resource not found |
+| `409 NO_ACTIVE_EVENT` | the operation needs an active event and none exists |
+| `409 PRINTER_*` | printer connection problems (with `details.target` + `details.hint`) |
+| `409` | other conflicts (e.g. locked resource, duplicate) |
+| `422` | validation failed (e.g. `OUT_OF_STOCK` carries `details.insufficient`) |
+| `423 USER_LOCKED` | the account is locked |
+
+The typed client in [`packages/api-client`](../packages/api-client) maps these onto an
+error class hierarchy (`ApiAuthError`, `ApiForbiddenError`, `ApiNotFoundError`,
+`ApiNoActiveEventError`, `ApiPrinterError`, `ApiConflictError`, `ApiValidationError`),
+so app code can `catch` specific failures instead of inspecting status codes.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -6,7 +6,7 @@ over a local network, with no cloud.** That shapes the whole system.
 ## System overview
 
 ```
-packages/shared-types  ──(Zod schemas + types)──┐
+packages/shared-types  ──(Zod schemas + types)───┐
         │                                        │
         ├──> packages/api-client ──> apps that call the API
         ├──> packages/auth-context ──> React apps (auth state)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,113 @@
+# Architecture
+
+Serva is designed around one constraint: **everything runs on the operator's laptop
+over a local network, with no cloud.** That shapes the whole system.
+
+## System overview
+
+```
+packages/shared-types  ──(Zod schemas + types)──┐
+        │                                        │
+        ├──> packages/api-client ──> apps that call the API
+        ├──> packages/auth-context ──> React apps (auth state)
+        └──> apps/api (runtime validation + OpenAPI)
+```
+
+- **`apps/api`** is the only component that owns data. It runs on the operator laptop,
+  exposes a REST API, validates every request, and serves the waiter PWA at `/waiter/`.
+- **`apps/waiter-web`** (phones) and **`apps/admin-desktop`** (operator) are clients.
+  They never touch the database directly — they go through the typed `api-client`.
+- **`packages/shared-types`** is the contract both sides share, so a change to a request
+  or response shape is a compile error on whichever side falls out of sync.
+
+## The shared-types contract
+
+`packages/shared-types/src/index.ts` exports every Zod schema and its inferred
+TypeScript type used for API requests and responses. The API uses
+`fastify-type-provider-zod`, so **the same schemas drive both runtime validation and the
+generated OpenAPI/Swagger spec**. Both frontends import these types via `api-client`.
+
+The Prisma schema (`apps/api/prisma/schema.prisma`) and its migration SQL describe the
+event-database shape. Prisma is used for migrations/DDL; at runtime the domain stores use
+raw `better-sqlite3` SQL rather than the Prisma client.
+
+## Two-database model
+
+Serva isolates each event in its own SQLite file:
+
+- **`apps/api/data/control.db`** — the registry. Tracks every event plus its control
+  metadata: which event is active, admin credentials, the hashed waiter passcode,
+  `closedAt`, etc. Managed by `EventStore`.
+- **`apps/api/data/events/event-<id>.db`** — one file per event. Holds that event's
+  menu, tables, users, orders, stock, printers, and order displays.
+
+Why per-event files: an event is a self-contained unit. Isolating it keeps data clean,
+makes "close" and "delete" trivial (deactivate clears the active flag; delete removes the
+file), and avoids cross-event leakage.
+
+### Active-event semantics
+
+- Exactly **one** event is active at a time. Activating one deactivates any other.
+- Endpoints that need event data declare `requiresActiveEvent` and return
+  `409 NO_ACTIVE_EVENT` when none is active.
+- **Deactivate** (`POST /admin/events/:id/deactivate`) is a temporary off switch.
+- **Close** (`POST /admin/events/:id/close`) is terminal — sets `closedAt`, clears the
+  active flag, and can't be repeated.
+- **Delete** (`DELETE /admin/events/:id`) removes the control entry and the event's
+  database file.
+
+## Store pattern
+
+All domain logic lives in `apps/api/src/domain/*-store.ts` (menu, tables, users, orders,
+stock, printers, order-displays, announcements, config, auth). Each store:
+
+1. Receives `EventStore` in its constructor.
+2. Calls `eventStore.getActiveEvent()` to resolve the active event's DB file path.
+3. Opens a fresh `better-sqlite3` connection to that file per operation and ensures its
+   schema exists.
+
+The singletons are wired together in `apps/api/src/domain/state.ts` and imported by the
+route modules in `apps/api/src/routes/*`.
+
+## Request lifecycle & route guards
+
+The Fastify app is composed in `apps/api/src/app.ts`. Routes declare their auth
+requirements **declaratively** in Fastify's route `config` object instead of writing
+inline checks; `preHandler` hooks (in `apps/api/src/plugins/*`) read those flags:
+
+| Config flag | Effect |
+|---|---|
+| `requiresAuth: true` | validates the Bearer JWT and attaches `request.auth` |
+| `requiresRole: "master" \| "admin" \| "waiter"` | requires that exact role |
+| `allowedRoles: string[]` | requires any of the listed roles |
+| `requiresActiveEvent: true` | rejects with `NO_ACTIVE_EVENT` if no event is active |
+
+The plugins involved: `jwt-auth-guard` (token validation), `admin-auth-guard`,
+`active-event-guard`, `error-handler` (uniform error envelopes), and `log-buffer` (an
+in-memory log ring exposed via the logs route).
+
+The app also serves the built waiter PWA statically at `/waiter/` and falls back to
+`index.html` for client-side deep links under that prefix (so a phone can reload any
+waiter route).
+
+## Auth roles
+
+| Role | How obtained | Scope |
+|---|---|---|
+| `master` | `POST /auth/master/login` with `MASTER_USERNAME`/`MASTER_PASSWORD` | global; only the event-lifecycle endpoints under `/admin/events/*` |
+| `admin` | `POST /auth/admin/login` with event ID + admin credentials | one event; manages that event's menu/tables/users/etc. |
+| `waiter` | `POST /auth/login` with username + event passcode | one event; the waiter ordering routes |
+
+JWTs carry role-specific claims — `master` → `role`; `admin`/`waiter` → `role + eventId +
+username`. On every authenticated request, `jwt-auth-guard` validates the token and
+attaches `request.auth`.
+
+See the [API Guide](api.md) for concrete request/response examples and the error model.
+
+## Networking & transport
+
+- The API binds `HOST` (default `0.0.0.0`) so phones on the LAN can reach it.
+- If a TLS cert exists at `apps/api/tls/` (created by `pnpm --filter api gen-cert`), the
+  API serves **HTTPS** on `HTTPS_PORT` (8443) *and* plain HTTP on `PORT` (8787) for
+  backwards compatibility. Without a cert, it serves HTTP only. HTTPS matters because the
+  waiter PWA's camera-based QR scanner requires a secure context on phones.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,141 @@
+# Getting Started
+
+This guide takes you from a fresh clone to a running Serva stack, including reaching
+the waiter app from real phones.
+
+## 1. Prerequisites
+
+- **Node.js 20.19+** (22 LTS recommended).
+- **pnpm 10** (`pnpm@10.33.0` is pinned by the repo). Recommended install via Corepack:
+  ```bash
+  corepack enable
+  corepack prepare pnpm@10.33.0 --activate
+  ```
+- **Rust toolchain** — only for `admin-desktop` (Tauri v2). Follow the
+  [Tauri prerequisites](https://v2.tauri.app/start/prerequisites/). On Windows you also
+  need the WebView2 runtime and the MSVC C++ build tools. Skip this if you only need the
+  API and waiter PWA.
+
+## 2. Install
+
+```bash
+git clone https://github.com/DeltaAT/Serva.git
+cd Serva
+pnpm install
+```
+
+## 3. Build the shared packages
+
+The apps import the **compiled** output of the workspace packages, so build them once:
+
+```bash
+pnpm build
+```
+
+Re-run this (or `pnpm --filter @serva/shared-types build`) whenever you change an API
+contract in `packages/shared-types`.
+
+## 4. Configure the API
+
+```bash
+cp apps/api/.env.example apps/api/.env
+```
+
+Edit `apps/api/.env` and set at least:
+
+| Variable | Purpose |
+|---|---|
+| `MASTER_USERNAME` / `MASTER_PASSWORD` | the global operator login |
+| `JWT_SECRET` | long random string used to sign tokens |
+| `DATABASE_URL` | Prisma connection string (default `file:./dev.db` is fine) |
+
+Optional: `HOST`, `PORT` (default `8787`), `HTTPS_PORT` (default `8443`),
+`PRINTER_TEST_PRINT_TIMEOUT_MS`.
+
+If you'll run the desktop app too: `cp apps/admin-desktop/.env.example apps/admin-desktop/.env`.
+
+## 5. Run
+
+```bash
+pnpm dev
+```
+
+This runs every workspace that has a `dev` script in parallel:
+
+| Service | URL |
+|---|---|
+| API (HTTP) | http://localhost:8787 |
+| Swagger UI | http://localhost:8787/documentation |
+| Waiter PWA (Vite dev) | http://localhost:5173/waiter/ |
+| Admin desktop | a Tauri window (needs Rust) |
+
+Run pieces individually if you prefer:
+
+```bash
+pnpm --filter api dev               # backend only (port 8787)
+pnpm --filter waiter-web dev        # waiter PWA only (Vite, port 5173)
+pnpm --filter appsadmin-desktop tauri dev   # desktop app only
+```
+
+## 6. First run — create an event
+
+The database starts empty. Use the **master** account to create and activate an event
+before anything else works. The quickest way is the Swagger UI
+(`/documentation`) or the PowerShell snippets in
+[`apps/api/README.md`](../apps/api/README.md#master-flow-create-event). In short:
+
+1. `POST /auth/master/login` with your master credentials → copy the `accessToken`.
+2. `POST /admin/events` with an `eventName`, `eventPasscode`, `adminUsername`,
+   `adminPassword`.
+3. `POST /admin/events/{id}/activate`.
+
+Now an admin can log in (`POST /auth/admin/login`) to build the menu/tables, and
+waiters can log in (`POST /auth/login`) with their name + the event passcode. See the
+[API Guide](api.md) for the full flow.
+
+## Running on phones (HTTPS)
+
+Phones reach the operator laptop over the local network. Two things matter:
+
+1. **Use the laptop's LAN IP**, not `localhost`. The API binds `0.0.0.0`, so phones can
+   reach it at `http(s)://<laptop-ip>:<port>`. Find the IP with `ipconfig` (Windows) or
+   `ip addr` / `ifconfig` (macOS/Linux). Make sure the laptop firewall allows inbound
+   connections on the API port.
+2. **Enable HTTPS** — the QR scanner uses the camera, which browsers only allow in a
+   secure context. Generate a self-signed certificate:
+   ```bash
+   pnpm --filter api gen-cert      # writes apps/api/tls/cert.pem + key.pem
+   pnpm --filter waiter-web build  # build the PWA so the API serves it at /waiter/
+   pnpm --filter api dev
+   ```
+   The API now also listens on `https://<laptop-ip>:8443`. Open
+   `https://<laptop-ip>:8443/waiter/` on the phone and accept the certificate warning
+   once.
+
+> In dev (`pnpm dev`), the waiter PWA is served by Vite on port `5173` at `/waiter/`.
+> For phone/QR use, build the PWA and let the API serve it over HTTPS as above.
+
+## Troubleshooting
+
+- **`Cannot find module '@serva/shared-types'` (or `api-client`/`auth-context`)** — you
+  skipped step 3. Run `pnpm build`.
+- **API responds `409 NO_ACTIVE_EVENT`** — no event is active. Create and activate one
+  (step 6).
+- **Phone can't load the app** — you used `localhost` instead of the laptop IP, the
+  firewall is blocking the port, or the phone is on a different network/VLAN.
+- **Camera/QR scanner won't start on the phone** — you're on `http://`. Use the HTTPS
+  setup above (camera needs a secure context).
+- **`HTTPS disabled` log line** — no cert found; run `pnpm --filter api gen-cert`.
+- **Changed a schema in `shared-types` but apps don't see it** — rebuild it
+  (`pnpm --filter @serva/shared-types build`).
+
+## Verifying the backend (smoke test)
+
+With the API running:
+
+```powershell
+powershell -File apps/api/scripts/smoke-test.ps1 -BaseUrl http://localhost:8787
+```
+
+It exercises master login, the event lifecycle, waiter/admin guards, CRUD flows,
+QR/PDF export, and Swagger UI loading.


### PR DESCRIPTION
Closes #103.

## Summary
- Replace the README stub with a full project overview: architecture diagram, monorepo layout, prerequisites, quick start, usage flow, phones/HTTPS, testing, and docs links.
- Add `docs/` guides: index, getting-started, architecture, and an API guide whose endpoint/role reference is extracted from the actual route guard configs.
- Add `apps/api/.env.example` and `apps/admin-desktop/.env.example` (`.env` is gitignored, so users had nothing to copy).
- Replace the default Vite/Tauri template READMEs in `waiter-web` and `admin-desktop` with real, project-specific docs.

## Test plan
- [ ] README renders cleanly on GitHub; links to `docs/` resolve
- [ ] `docs/api.md` roles match the route guard configs
- [ ] `cp apps/api/.env.example apps/api/.env` gives a working starting config

🤖 Generated with [Claude Code](https://claude.com/claude-code)