### PR TITLE
Serva-104 feat(admin-desktop): live statistics page

### DIFF
--- a/apps/admin-desktop/src/App.css
+++ b/apps/admin-desktop/src/App.css
@@ -2136,3 +2136,204 @@ html, body, #root {
   border-left-color: #b91c1c;
 }
 .log-row--fatal .log-level { color: #f87171; }
+
+/* ===========================================================================
+   Statistics page
+   =========================================================================== */
+
+.stats-live {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 0.8rem;
+  color: var(--color-muted);
+}
+
+.stats-live__dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: #22c55e;
+  box-shadow: 0 0 0 0 rgba(34, 197, 94, 0.5);
+  animation: stats-pulse 1.8s ease-out infinite;
+}
+
+@keyframes stats-pulse {
+  0%   { box-shadow: 0 0 0 0 rgba(34, 197, 94, 0.45); }
+  70%  { box-shadow: 0 0 0 6px rgba(34, 197, 94, 0); }
+  100% { box-shadow: 0 0 0 0 rgba(34, 197, 94, 0); }
+}
+
+.stats-kpi-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: 12px;
+  margin-bottom: 16px;
+}
+
+.stat-card {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 16px 18px;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-card);
+}
+
+.stat-card--accent {
+  background: linear-gradient(135deg, var(--color-brand), var(--color-brand-dark));
+  border-color: transparent;
+}
+
+.stat-card__value {
+  font-size: 1.6rem;
+  font-weight: 700;
+  line-height: 1.1;
+  color: var(--color-text);
+}
+
+.stat-card__label {
+  font-size: 0.78rem;
+  font-weight: 500;
+  color: var(--color-muted);
+}
+
+.stat-card--accent .stat-card__value { color: #fff; }
+.stat-card--accent .stat-card__label { color: rgba(255, 255, 255, 0.85); }
+
+.stats-charts {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 16px;
+}
+
+.chart-card {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.chart-card--wide {
+  grid-column: 1 / -1;
+}
+
+/* Vertical bar chart: orders over time */
+.barchart {
+  width: 100%;
+}
+
+.barchart__cols {
+  display: flex;
+  align-items: flex-end;
+  gap: 6px;
+  height: 180px;
+}
+
+.barchart__col {
+  flex: 1 1 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  height: 100%;
+  min-width: 0;
+}
+
+.barchart__bar-wrap {
+  flex: 1;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  align-items: center;
+  gap: 2px;
+}
+
+.barchart__count {
+  font-size: 0.7rem;
+  font-weight: 600;
+  color: var(--color-muted);
+  height: 0.9rem;
+}
+
+.barchart__bar {
+  width: 100%;
+  max-width: 36px;
+  min-height: 2px;
+  border-radius: 4px 4px 0 0;
+  background: linear-gradient(180deg, var(--color-brand), var(--color-brand-dark));
+  transition: height 0.3s ease;
+}
+
+.barchart__tick {
+  margin-top: 6px;
+  font-size: 0.68rem;
+  color: var(--color-muted);
+  white-space: nowrap;
+}
+
+/* Horizontal ranked bars: top items, per waiter */
+.hbar-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.hbar {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.hbar__head {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 8px;
+}
+
+.hbar__label {
+  font-size: 0.88rem;
+  font-weight: 500;
+  color: var(--color-text);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.hbar__value {
+  font-size: 0.88rem;
+  font-weight: 700;
+  color: var(--color-text);
+  flex-shrink: 0;
+}
+
+.hbar__track {
+  width: 100%;
+  height: 8px;
+  background: #f3f4f6;
+  border-radius: 999px;
+  overflow: hidden;
+}
+
+.hbar__fill {
+  height: 100%;
+  border-radius: 999px;
+  background: linear-gradient(90deg, var(--color-brand), var(--color-brand-dark));
+  transition: width 0.3s ease;
+}
+
+.hbar__secondary {
+  font-size: 0.74rem;
+  color: var(--color-muted);
+}
+
+@media (max-width: 860px) {
+  .stats-charts {
+    grid-template-columns: 1fr;
+  }
+}

--- a/apps/admin-desktop/src/App.tsx
+++ b/apps/admin-desktop/src/App.tsx
@@ -14,6 +14,7 @@ import { UsersPage } from "./pages/UsersPage";
 import { StockPage } from "./pages/StockPage";
 import { ConfigPage } from "./pages/ConfigPage";
 import { OrdersPage } from "./pages/OrdersPage";
+import { StatisticsPage } from "./pages/StatisticsPage";
 import { LogsPage } from "./pages/LogsPage";
 import "./App.css";
 
@@ -105,6 +106,7 @@ function AppRoutes() {
           <Route path="stock"          element={<StockPage />} />
           <Route path="config"         element={<ConfigPage />} />
           <Route path="orders"         element={<OrdersPage />} />
+          <Route path="statistics"     element={<StatisticsPage />} />
           <Route path="logs"           element={<LogsPage />} />
         </Route>
       </Route>

--- a/apps/admin-desktop/src/components/AdminShell.tsx
+++ b/apps/admin-desktop/src/components/AdminShell.tsx
@@ -13,6 +13,7 @@ const NAV_ITEMS = [
   { segment: "users",          label: "Benutzer" },
   { segment: "stock",          label: "Lager" },
   { segment: "orders",         label: "Bestellungen" },
+  { segment: "statistics",     label: "Statistik" },
   { segment: "logs",           label: "Logs" },
   { segment: "config",         label: "Einstellungen" },
 ] as const;

--- a/apps/admin-desktop/src/pages/StatisticsPage.tsx
+++ b/apps/admin-desktop/src/pages/StatisticsPage.tsx
@@ -1,0 +1,431 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import type { MenuItemDto, OrderDto, UserDto } from "@serva/shared-types";
+import { useApiClient } from "../contexts/ApiClientContext";
+
+// ---------------------------------------------------------------------------
+// Constants & helpers
+// ---------------------------------------------------------------------------
+
+const POLL_INTERVAL_MS = 5000;
+
+const eur = new Intl.NumberFormat("de-DE", {
+  style: "currency",
+  currency: "EUR",
+});
+
+const int = new Intl.NumberFormat("de-DE");
+
+const clockFmt = new Intl.DateTimeFormat("de-DE", {
+  hour: "2-digit",
+  minute: "2-digit",
+  second: "2-digit",
+});
+
+const hhmmFmt = new Intl.DateTimeFormat("de-DE", {
+  hour: "2-digit",
+  minute: "2-digit",
+});
+
+// Candidate bucket sizes (ms) for the time chart, smallest first.
+const BUCKET_SIZES_MS = [
+  5 * 60_000,
+  15 * 60_000,
+  30 * 60_000,
+  60 * 60_000,
+  2 * 60 * 60_000,
+  4 * 60 * 60_000,
+  6 * 60 * 60_000,
+  12 * 60 * 60_000,
+  24 * 60 * 60_000,
+];
+const MAX_BUCKETS = 16;
+
+interface TimeBucket {
+  start: number;
+  count: number;
+  revenue: number;
+}
+
+interface RankedRow {
+  key: number;
+  label: string;
+  primary: number; // revenue (drives bar width)
+  secondary: number; // qty or order count
+}
+
+// ---------------------------------------------------------------------------
+// Aggregation
+// ---------------------------------------------------------------------------
+
+interface Stats {
+  revenue: number;
+  orderCount: number;
+  itemCount: number;
+  avgOrderValue: number;
+  activeWaiters: number;
+  buckets: TimeBucket[];
+  topItems: RankedRow[];
+  byWaiter: RankedRow[];
+}
+
+function computeStats(
+  orders: OrderDto[],
+  prices: Map<number, MenuItemDto>,
+  waiterName: Map<number, string>,
+): Stats {
+  let revenue = 0;
+  let itemCount = 0;
+  const waiterIds = new Set<number>();
+
+  const itemAgg = new Map<number, { qty: number; revenue: number }>();
+  const waiterAgg = new Map<number, { orders: number; revenue: number }>();
+
+  for (const order of orders) {
+    waiterIds.add(order.userId);
+    let orderRevenue = 0;
+    for (const item of order.items) {
+      const price = prices.get(item.menuItemId)?.price ?? 0;
+      const line = price * item.quantity;
+      revenue += line;
+      orderRevenue += line;
+      itemCount += item.quantity;
+
+      const ia = itemAgg.get(item.menuItemId) ?? { qty: 0, revenue: 0 };
+      ia.qty += item.quantity;
+      ia.revenue += line;
+      itemAgg.set(item.menuItemId, ia);
+    }
+    const wa = waiterAgg.get(order.userId) ?? { orders: 0, revenue: 0 };
+    wa.orders += 1;
+    wa.revenue += orderRevenue;
+    waiterAgg.set(order.userId, wa);
+  }
+
+  const orderCount = orders.length;
+
+  // Top items by revenue (top 6).
+  const topItems: RankedRow[] = [...itemAgg.entries()]
+    .map(([id, v]) => ({
+      key: id,
+      label: prices.get(id)?.name ?? `#${id}`,
+      primary: v.revenue,
+      secondary: v.qty,
+    }))
+    .sort((a, b) => b.primary - a.primary)
+    .slice(0, 6);
+
+  // Revenue per waiter (top 6).
+  const byWaiter: RankedRow[] = [...waiterAgg.entries()]
+    .map(([id, v]) => ({
+      key: id,
+      label: waiterName.get(id) ?? `#${id}`,
+      primary: v.revenue,
+      secondary: v.orders,
+    }))
+    .sort((a, b) => b.primary - a.primary)
+    .slice(0, 6);
+
+  return {
+    revenue,
+    orderCount,
+    itemCount,
+    avgOrderValue: orderCount > 0 ? revenue / orderCount : 0,
+    activeWaiters: waiterIds.size,
+    buckets: buildTimeBuckets(orders, prices),
+    topItems,
+    byWaiter,
+  };
+}
+
+function buildTimeBuckets(
+  orders: OrderDto[],
+  prices: Map<number, MenuItemDto>,
+): TimeBucket[] {
+  if (orders.length === 0) return [];
+
+  const times = orders.map((o) => new Date(o.timestamp).getTime());
+  const min = Math.min(...times);
+  const now = Date.now();
+  const span = Math.max(now - min, 60_000);
+
+  let size = BUCKET_SIZES_MS[BUCKET_SIZES_MS.length - 1];
+  for (const candidate of BUCKET_SIZES_MS) {
+    if (Math.ceil(span / candidate) <= MAX_BUCKETS) {
+      size = candidate;
+      break;
+    }
+  }
+
+  const start = Math.floor(min / size) * size;
+  const count = Math.min(MAX_BUCKETS, Math.ceil((now - start) / size) + 1);
+
+  const buckets: TimeBucket[] = [];
+  for (let i = 0; i < count; i += 1) {
+    buckets.push({ start: start + i * size, count: 0, revenue: 0 });
+  }
+
+  for (const order of orders) {
+    const t = new Date(order.timestamp).getTime();
+    const idx = Math.floor((t - start) / size);
+    if (idx < 0 || idx >= buckets.length) continue;
+    const bucket = buckets[idx];
+    bucket.count += 1;
+    for (const item of order.items) {
+      bucket.revenue += (prices.get(item.menuItemId)?.price ?? 0) * item.quantity;
+    }
+  }
+
+  return buckets;
+}
+
+// ---------------------------------------------------------------------------
+// Presentational pieces
+// ---------------------------------------------------------------------------
+
+function StatCard({
+  label,
+  value,
+  accent,
+}: {
+  label: string;
+  value: string;
+  accent?: boolean;
+}) {
+  return (
+    <div className={`stat-card${accent ? " stat-card--accent" : ""}`}>
+      <span className="stat-card__value">{value}</span>
+      <span className="stat-card__label">{label}</span>
+    </div>
+  );
+}
+
+function TimeBarChart({ buckets }: { buckets: TimeBucket[] }) {
+  const max = Math.max(1, ...buckets.map((b) => b.count));
+  // Label at most ~6 ticks so the axis doesn't crowd.
+  const tickStep = Math.max(1, Math.ceil(buckets.length / 6));
+
+  return (
+    <div className="barchart" role="img" aria-label="Bestellungen im Zeitverlauf">
+      <div className="barchart__cols">
+        {buckets.map((b, i) => {
+          const heightPct = (b.count / max) * 100;
+          return (
+            <div className="barchart__col" key={b.start}>
+              <div className="barchart__bar-wrap">
+                <span className="barchart__count">{b.count > 0 ? b.count : ""}</span>
+                <div
+                  className="barchart__bar"
+                  style={{ height: `${heightPct}%` }}
+                  title={`${hhmmFmt.format(new Date(b.start))} · ${b.count} Bestellungen · ${eur.format(b.revenue)}`}
+                />
+              </div>
+              <span className="barchart__tick">
+                {i % tickStep === 0 ? hhmmFmt.format(new Date(b.start)) : ""}
+              </span>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+function RankedBars({
+  rows,
+  valueFormat,
+  secondaryLabel,
+}: {
+  rows: RankedRow[];
+  valueFormat: (n: number) => string;
+  secondaryLabel: (n: number) => string;
+}) {
+  const max = Math.max(1, ...rows.map((r) => r.primary));
+  return (
+    <ul className="hbar-list">
+      {rows.map((r) => (
+        <li className="hbar" key={r.key}>
+          <div className="hbar__head">
+            <span className="hbar__label" title={r.label}>
+              {r.label}
+            </span>
+            <span className="hbar__value">{valueFormat(r.primary)}</span>
+          </div>
+          <div className="hbar__track">
+            <div
+              className="hbar__fill"
+              style={{ width: `${(r.primary / max) * 100}%` }}
+            />
+          </div>
+          <span className="hbar__secondary">{secondaryLabel(r.secondary)}</span>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// StatisticsPage
+// ---------------------------------------------------------------------------
+
+type LoadState =
+  | { status: "loading" }
+  | { status: "error"; message: string }
+  | { status: "ok" };
+
+export function StatisticsPage() {
+  const api = useApiClient();
+
+  const [state, setState] = useState<LoadState>({ status: "loading" });
+  const [orders, setOrders] = useState<OrderDto[]>([]);
+  const [prices, setPrices] = useState<Map<number, MenuItemDto>>(new Map());
+  const [waiterName, setWaiterName] = useState<Map<number, string>>(new Map());
+  const [tableCount, setTableCount] = useState(0);
+  const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
+
+  const inFlight = useRef(false);
+
+  const load = useCallback(
+    async (showLoading: boolean) => {
+      if (inFlight.current) return;
+      inFlight.current = true;
+      if (showLoading) setState({ status: "loading" });
+      try {
+        const [ordersRes, itemsRes, usersRes, tablesRes] = await Promise.all([
+          api.orders.list({}),
+          api.menu.listItems(),
+          api.users.list(),
+          api.tables.list(),
+        ]);
+        setOrders(ordersRes.orders);
+        setPrices(new Map(itemsRes.items.map((i: MenuItemDto) => [i.id, i])));
+        setWaiterName(
+          new Map(usersRes.users.map((u: UserDto) => [u.id, u.username])),
+        );
+        setTableCount(tablesRes.tables.length);
+        setLastUpdated(new Date());
+        setState({ status: "ok" });
+      } catch (err) {
+        setState({
+          status: "error",
+          message: err instanceof Error ? err.message : "Fehler beim Laden.",
+        });
+      } finally {
+        inFlight.current = false;
+      }
+    },
+    [api],
+  );
+
+  useEffect(() => {
+    load(true);
+  }, [load]);
+
+  useEffect(() => {
+    const id = setInterval(() => load(false), POLL_INTERVAL_MS);
+    return () => clearInterval(id);
+  }, [load]);
+
+  const stats = useMemo(
+    () => computeStats(orders, prices, waiterName),
+    [orders, prices, waiterName],
+  );
+
+  const header = (
+    <div className="page-header">
+      <h1 className="page-title">Statistik</h1>
+      <span className="stats-live">
+        <span className="stats-live__dot" aria-hidden="true" />
+        Live · alle 5&nbsp;Sekunden
+        {lastUpdated && (
+          <span className="muted">
+            {" "}
+            (zuletzt {clockFmt.format(lastUpdated)})
+          </span>
+        )}
+      </span>
+    </div>
+  );
+
+  if (state.status === "loading" && orders.length === 0) {
+    return (
+      <div>
+        {header}
+        <div className="overview-loading">Wird geladen…</div>
+      </div>
+    );
+  }
+
+  if (state.status === "error" && orders.length === 0) {
+    return (
+      <div>
+        {header}
+        <p className="form-error">{state.message}</p>
+        <button
+          className="btn-secondary"
+          style={{ marginTop: 12 }}
+          onClick={() => load(true)}
+        >
+          Erneut versuchen
+        </button>
+      </div>
+    );
+  }
+
+  const hasOrders = orders.length > 0;
+
+  return (
+    <div>
+      {header}
+
+      <div className="stats-kpi-grid">
+        <StatCard label="Umsatz" value={eur.format(stats.revenue)} accent />
+        <StatCard label="Bestellungen" value={int.format(stats.orderCount)} />
+        <StatCard label="Artikel verkauft" value={int.format(stats.itemCount)} />
+        <StatCard label="Ø Bestellwert" value={eur.format(stats.avgOrderValue)} />
+        <StatCard
+          label="Aktive Kellner"
+          value={`${int.format(stats.activeWaiters)} / ${int.format(waiterName.size)}`}
+        />
+        <StatCard label="Tische" value={int.format(tableCount)} />
+      </div>
+
+      {!hasOrders ? (
+        <div
+          className="overview-card"
+          style={{ textAlign: "center", padding: "40px 24px", marginTop: 16 }}
+        >
+          <p className="muted">
+            Noch keine Bestellungen — Statistiken erscheinen, sobald bestellt wird.
+          </p>
+        </div>
+      ) : (
+        <div className="stats-charts">
+          <div className="overview-card chart-card chart-card--wide">
+            <span className="section-title">Bestellungen im Zeitverlauf</span>
+            <TimeBarChart buckets={stats.buckets} />
+          </div>
+
+          <div className="overview-card chart-card">
+            <span className="section-title">Top-Artikel nach Umsatz</span>
+            <RankedBars
+              rows={stats.topItems}
+              valueFormat={(n) => eur.format(n)}
+              secondaryLabel={(n) => `${int.format(n)}× verkauft`}
+            />
+          </div>
+
+          <div className="overview-card chart-card">
+            <span className="section-title">Umsatz pro Kellner</span>
+            <RankedBars
+              rows={stats.byWaiter}
+              valueFormat={(n) => eur.format(n)}
+              secondaryLabel={(n) =>
+                `${int.format(n)} ${n === 1 ? "Bestellung" : "Bestellungen"}`
+              }
+            />
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #104.

## Summary
- New **Statistik** page in the admin panel with live KPIs (revenue, orders, items sold, average order value, active waiters, tables).
- Charts (plain SVG/CSS, no new dependency): orders over time (adaptive time buckets), top items by revenue, and revenue per waiter.
- Polls every 5s with a pulsing live indicator and last-updated timestamp; graceful loading/error/empty states.
- Aggregated client-side from orders + menu prices + users + tables. Wired into the route tree and sidebar.

## Test plan
- [ ] `pnpm --filter appsadmin-desktop build` passes (tsc + vite)
- [ ] With an active event + some orders, the page shows non-zero KPIs and charts
- [ ] Placing a new order updates the page within ~5s
- [ ] Empty state renders when there are no orders yet

🤖 Generated with [Claude Code](https://claude.com/claude-code)