### PR TITLE
Serva-113 chore(waiter-web): remove special request qty stepper in cart

### DIFF
--- a/apps/waiter-web/src/index.css
+++ b/apps/waiter-web/src/index.css
@@ -2462,8 +2462,10 @@ body {
   color: var(--color-text);
 }
 
-.sr-list__stepper {
+.sr-list__qty {
   flex-shrink: 0;
+  font-weight: 600;
+  color: var(--color-accent);
 }
 
 /* ─── Special request dialog ────────────────────────────────── */

--- a/apps/waiter-web/src/pages/OrderPage.tsx
+++ b/apps/waiter-web/src/pages/OrderPage.tsx
@@ -117,7 +117,6 @@ export function OrderPage() {
     removeItem,
     clearCart,
     payItems,
-    setSpecialRequestQty,
   } = useCart()
 
   const tableName =
@@ -328,7 +327,6 @@ export function OrderPage() {
                 openQty={openQty}
                 onRemove={() => removeItem(line.item.id)}
                 onSetSubBillQty={(qty) => setSubBillQty(line.item.id, qty)}
-                onSetSpecialRequestQty={(idx, qty) => setSpecialRequestQty(line.item.id, idx, qty)}
               />
             )
           })}
@@ -403,7 +401,6 @@ interface CartItemRowProps {
   openQty: number
   onRemove(): void
   onSetSubBillQty(qty: number): void
-  onSetSpecialRequestQty(index: number, qty: number): void
 }
 
 function CartItemRow({
@@ -414,7 +411,6 @@ function CartItemRow({
   openQty,
   onRemove,
   onSetSubBillQty,
-  onSetSpecialRequestQty,
 }: CartItemRowProps) {
   const { item, qty, specialRequests, paidQty } = line
   const units = lineUnits(line)
@@ -514,24 +510,8 @@ function CartItemRow({
         <ul className="sr-list sr-list--order" aria-label={`Sonderwünsche für ${item.name}`}>
           {specialRequests.map((sr, idx) => (
             <li key={idx} className="sr-list__item">
+              {sr.qty > 1 && <span className="sr-list__qty">{sr.qty}&times;</span>}
               <span className="sr-list__text">{sr.text}</span>
-              <div className="stepper sr-list__stepper" role="group" aria-label={`Anzahl: ${sr.text}`}>
-                <button
-                  type="button"
-                  className="stepper__btn"
-                  onClick={() => onSetSpecialRequestQty(idx, sr.qty - 1)}
-                  disabled={disabled}
-                  aria-label="Eins weniger"
-                >&#8722;</button>
-                <span className="stepper__value">{sr.qty}</span>
-                <button
-                  type="button"
-                  className="stepper__btn stepper__btn--add"
-                  onClick={() => onSetSpecialRequestQty(idx, sr.qty + 1)}
-                  disabled={disabled}
-                  aria-label="Eins mehr"
-                >+</button>
-              </div>
             </li>
           ))}
         </ul>


### PR DESCRIPTION
Closes #113

## Scope
- Removes the `+`/`−` quantity stepper for special requests from the order/cart screen (`OrderPage`).

## Changes
- `apps/waiter-web/src/pages/OrderPage.tsx`: special-request rows in the cart are now read-only (text, prefixed `Nx` only when qty > 1). Removed the unused `onSetSpecialRequestQty` prop and the `setSpecialRequestQty` cart binding from this page.
- `apps/waiter-web/src/index.css`: replaced the dead `.sr-list__stepper` rule with a `.sr-list__qty` badge style.

Quantity is still set from the menu screen (`MenuPage`), so the underlying cart action is unchanged.

## Acceptance criteria
- ✅ Waiter can no longer change the quantity of a special request in the cart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)