### PR TITLE
Ship Serva as a self-contained all-in-one desktop installer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -162,3 +162,7 @@ dist
 .idea
 *.iml
 gen
+
+# Serva: generated API bundle + staged Tauri runtime (built by build:runtime)
+apps/api/build/
+apps/admin-desktop/src-tauri/resources/

--- a/apps/admin-desktop/package.json
+++ b/apps/admin-desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "appsadmin-desktop",
   "private": true,
-  "version": "0.1.0",
+  "version": "1.0.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/apps/admin-desktop/src-tauri/Cargo.toml
+++ b/apps/admin-desktop/src-tauri/Cargo.toml
@@ -1,8 +1,10 @@
 [package]
 name = "appsadmin-desktop"
-version = "0.1.0"
-description = "A Tauri App"
-authors = ["you"]
+# Auto-synced from the root package.json by scripts/sync-versions.mjs.
+# Do not edit by hand — bump "version" in the root package.json instead.
+version = "1.0.0"
+description = "Desktop App for Serva"
+authors = ["Elias Pöschl (@DeltaAT)"]
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -22,4 +24,5 @@ tauri = { version = "2", features = [] }
 tauri-plugin-opener = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+getrandom = "0.2"
 

--- a/apps/admin-desktop/src-tauri/src/lib.rs
+++ b/apps/admin-desktop/src-tauri/src/lib.rs
@@ -32,54 +32,123 @@ fn find_monorepo_api_root(start: &Path) -> Option<PathBuf> {
     None
 }
 
-/// Resolved spawn target for the API. We invoke Node directly with the tsx
-/// CLI rather than a built `dist/index.js` because the api package's tsc
-/// output emits extensionless ESM imports that Node won't resolve.
+/// Resolved spawn target for the API.
+///
+/// Production ships a private Node runtime plus an esbuild bundle, so we run
+/// `node.exe server.mjs`. In dev (monorepo) there is no bundle, so we fall
+/// back to the system `node` running the tsx CLI against `src/index.ts` —
+/// the api package's tsc output emits extensionless ESM imports Node won't
+/// resolve, which is why we use tsx rather than a built `dist/index.js`.
 struct ApiTarget {
-    api_root: PathBuf,
-    entry: PathBuf,
-    tsx_cli: PathBuf,
+    /// Executable to launch: the bundled private Node, or system `node` in dev.
+    program: PathBuf,
+    /// Args: `[server.mjs]` (bundled) or `[tsx_cli, src/index.ts]` (dev).
+    args: Vec<PathBuf>,
+    /// Working dir — the API writes `data/` and `tls/` relative to it, so it
+    /// must be writable. In production this is the app-data dir, NOT the
+    /// read-only resource dir.
+    cwd: PathBuf,
+    /// waiter-web `dist/`, served by the API at `/waiter`.
     waiter_dist: PathBuf,
+    /// True for the shipped self-contained runtime (no `.env`), false in dev.
+    /// Only the bundled runtime gets a generated, persisted JWT secret injected.
+    bundled: bool,
 }
 
-/// Resolves the API package layout and the waiter-web `dist/` directory.
-/// Lookup order:
-///   1. `SERVA_API_ROOT` / `SERVA_WAITER_DIST` env vars (explicit override).
-///   2. Tauri resource directory (`api/`, `waiter/`).
-///   3. Monorepo walk-up from the exe location.
+#[cfg(target_os = "windows")]
+const NODE_EXE: &str = "node.exe";
+#[cfg(not(target_os = "windows"))]
+const NODE_EXE: &str = "node";
+
+/// Hex-encoded cryptographically random string of `bytes` bytes.
+fn random_hex(bytes: usize) -> Option<String> {
+    let mut buf = vec![0u8; bytes];
+    getrandom::getrandom(&mut buf).ok()?;
+    Some(buf.iter().map(|b| format!("{:02x}", b)).collect())
+}
+
+/// Returns a stable JWT secret for the bundled API, generating and persisting a
+/// random one in the app-data dir on first run. Keeping it stable means tokens
+/// survive app restarts; keeping it private/random means it isn't the insecure
+/// dev default. Returns `None` only if app-data is unavailable or RNG fails, in
+/// which case the API falls back to its own default.
+fn ensure_jwt_secret(app: &tauri::AppHandle) -> Option<String> {
+    let dir = app.path().app_data_dir().ok()?;
+    let _ = std::fs::create_dir_all(&dir);
+    let path = dir.join("jwt-secret");
+
+    if let Ok(existing) = std::fs::read_to_string(&path) {
+        let trimmed = existing.trim();
+        if !trimmed.is_empty() {
+            return Some(trimmed.to_string());
+        }
+    }
+
+    let secret = random_hex(48)?;
+    std::fs::write(&path, &secret).ok()?;
+    Some(secret)
+}
+
+/// Resolves how to launch the API. Lookup order:
+///   1. Bundled runtime in the Tauri resource dir (`api/node.exe`,
+///      `api/server.mjs`, `waiter/`) — the shipped, self-contained path.
+///   2. `SERVA_API_ROOT` / `SERVA_WAITER_DIST` env vars (dev override).
+///   3. Monorepo walk-up from the exe location (dev).
 fn resolve_paths(app: &tauri::AppHandle) -> Option<ApiTarget> {
-    let try_root = |api_root: PathBuf, waiter_dist: PathBuf| -> Option<ApiTarget> {
+    // 1. Bundled self-contained runtime.
+    if let Ok(resource_dir) = app.path().resource_dir() {
+        let node = resource_dir.join("api").join(NODE_EXE);
+        let server = resource_dir.join("api").join("server.mjs");
+        let waiter = resource_dir.join("waiter");
+        if node.is_file() && server.is_file() && waiter.is_dir() {
+            // Writable working dir for the API's data/ and tls/ folders.
+            let cwd = app
+                .path()
+                .app_data_dir()
+                .unwrap_or_else(|_| resource_dir.clone());
+            let _ = std::fs::create_dir_all(&cwd);
+            return Some(ApiTarget {
+                program: node,
+                args: vec![server],
+                cwd,
+                waiter_dist: waiter,
+                bundled: true,
+            });
+        }
+    }
+
+    // Dev: system node + tsx against the TypeScript source.
+    let dev_target = |api_root: PathBuf, waiter_dist: PathBuf| -> Option<ApiTarget> {
         let entry = api_root.join("src/index.ts");
         let tsx_cli = api_root.join("node_modules/tsx/dist/cli.mjs");
         if entry.is_file() && tsx_cli.is_file() && waiter_dist.is_dir() {
-            Some(ApiTarget { api_root, entry, tsx_cli, waiter_dist })
+            Some(ApiTarget {
+                program: PathBuf::from(NODE_EXE),
+                args: vec![tsx_cli, entry],
+                cwd: api_root,
+                waiter_dist,
+                bundled: false,
+            })
         } else {
             None
         }
     };
 
+    // 2. Explicit dev override.
     if let (Ok(root), Ok(waiter)) = (
         std::env::var("SERVA_API_ROOT"),
         std::env::var("SERVA_WAITER_DIST"),
     ) {
-        if let Some(t) = try_root(PathBuf::from(root), PathBuf::from(waiter)) {
+        if let Some(t) = dev_target(PathBuf::from(root), PathBuf::from(waiter)) {
             return Some(t);
         }
     }
 
-    if let Ok(resource_dir) = app.path().resource_dir() {
-        if let Some(t) = try_root(resource_dir.join("api"), resource_dir.join("waiter")) {
-            return Some(t);
-        }
-    }
-
+    // 3. Monorepo walk-up.
     if let Ok(exe) = std::env::current_exe() {
         if let Some(api_root) = exe.parent().and_then(find_monorepo_api_root) {
-            let waiter = api_root
-                .parent() // apps/
-                .map(|p| p.join("waiter-web/dist"));
-            if let Some(waiter) = waiter {
-                if let Some(t) = try_root(api_root, waiter) {
+            if let Some(waiter) = api_root.parent().map(|p| p.join("waiter-web/dist")) {
+                if let Some(t) = dev_target(api_root, waiter) {
                     return Some(t);
                 }
             }
@@ -95,15 +164,14 @@ fn resolve_paths(app: &tauri::AppHandle) -> Option<ApiTarget> {
 fn spawn_api(app: &tauri::AppHandle) -> Result<Option<Child>, std::io::Error> {
     let Some(target) = resolve_paths(app) else {
         eprintln!(
-            "[serva] API not found — set SERVA_API_ROOT + SERVA_WAITER_DIST or run `pnpm install` + `pnpm --filter waiter-web build`. The admin GUI will start without an embedded API."
+            "[serva] API not found — bundled runtime missing and no dev source located. The admin GUI will start without an embedded API."
         );
         return Ok(None);
     };
 
-    let mut cmd = Command::new("node");
-    cmd.arg(&target.tsx_cli)
-        .arg(&target.entry)
-        .current_dir(&target.api_root)
+    let mut cmd = Command::new(&target.program);
+    cmd.args(&target.args)
+        .current_dir(&target.cwd)
         .env("WAITER_DIST_PATH", &target.waiter_dist)
         .env(
             "HOST",
@@ -116,16 +184,29 @@ fn spawn_api(app: &tauri::AppHandle) -> Result<Option<Child>, std::io::Error> {
         .stdout(Stdio::inherit())
         .stderr(Stdio::inherit());
 
+    // The bundled runtime has no .env, so give it a stable, private JWT secret
+    // (generated and persisted on first run) instead of the API's dev default.
+    if target.bundled {
+        if let Some(secret) = ensure_jwt_secret(app) {
+            cmd.env("JWT_SECRET", secret);
+        }
+    }
+
     #[cfg(target_os = "windows")]
     {
         cmd.creation_flags(CREATE_NO_WINDOW);
     }
 
+    let args_display: Vec<String> = target
+        .args
+        .iter()
+        .map(|a| a.display().to_string())
+        .collect();
     println!(
-        "[serva] starting API: node {} {} (cwd={}, WAITER_DIST_PATH={})",
-        target.tsx_cli.display(),
-        target.entry.display(),
-        target.api_root.display(),
+        "[serva] starting API: {} {} (cwd={}, WAITER_DIST_PATH={})",
+        target.program.display(),
+        args_display.join(" "),
+        target.cwd.display(),
         target.waiter_dist.display()
     );
     let child = cmd.spawn()?;

--- a/apps/admin-desktop/src-tauri/tauri.conf.json
+++ b/apps/admin-desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
-  "productName": "appsadmin-desktop",
-  "version": "0.1.0",
+  "productName": "Serva",
+  "version": "../../../package.json",
   "identifier": "com.fampo.appsadmin-desktop",
   "build": {
     "beforeDevCommand": "pnpm dev",
@@ -26,7 +26,11 @@
   },
   "bundle": {
     "active": true,
-    "targets": "all",
+    "targets": ["nsis"],
+    "resources": {
+      "resources/api": "api",
+      "resources/waiter": "waiter"
+    },
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",

--- a/apps/admin-desktop/src/pages/LoginPage.tsx
+++ b/apps/admin-desktop/src/pages/LoginPage.tsx
@@ -1,28 +1,76 @@
-import { useState, type FormEvent } from "react";
+import { useEffect, useState, type FormEvent } from "react";
 import { Navigate } from "react-router-dom";
 import { useAuth } from "@serva/auth-context";
+import { useApiClient } from "../contexts/ApiClientContext";
 import { WindowControls } from "../components/WindowControls";
 
 export function LoginPage() {
   const { role, eventId, isLoading, isLoggingIn, loginMaster } = useAuth();
+  const client = useApiClient();
 
   const [username, setUsername] = useState("");
   const [password, setPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
   const [error, setError] = useState<string | null>(null);
 
-  if (isLoading) return <div className="loading-screen">Laden...</div>;
+  // null = still checking whether master credentials exist.
+  const [configured, setConfigured] = useState<boolean | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    client.auth
+      .masterStatus()
+      .then((res) => {
+        if (!cancelled) setConfigured(res.configured);
+      })
+      .catch(() => {
+        // API unreachable — assume configured and let the login attempt surface
+        // the real connection error.
+        if (!cancelled) setConfigured(true);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [client]);
+
+  if (isLoading || configured === null) {
+    return <div className="loading-screen">Laden...</div>;
+  }
   if (role === "master") return <Navigate to="/events" replace />;
   if (role === "admin" && eventId != null) {
     return <Navigate to={`/events/${eventId}/menu`} replace />;
   }
 
-  async function handleSubmit(e: FormEvent) {
+  async function handleLogin(e: FormEvent) {
     e.preventDefault();
     setError(null);
     try {
       await loginMaster({ username, password });
     } catch {
       setError("Anmeldung fehlgeschlagen. Benutzername oder Passwort ist falsch.");
+    }
+  }
+
+  async function handleSetup(e: FormEvent) {
+    e.preventDefault();
+    setError(null);
+    if (password !== confirmPassword) {
+      setError("Die Passwörter stimmen nicht überein.");
+      return;
+    }
+    if (password.length < 8) {
+      setError("Das Passwort muss mindestens 8 Zeichen lang sein.");
+      return;
+    }
+    setSubmitting(true);
+    try {
+      await client.auth.masterSetup({ username, password });
+      // Immediately sign in with the freshly created credentials.
+      await loginMaster({ username, password });
+    } catch {
+      setError("Einrichtung fehlgeschlagen. Bitte erneut versuchen.");
+      setSubmitting(false);
     }
   }
 
@@ -35,23 +83,52 @@ export function LoginPage() {
       <div className="login-page">
         <div className="login-card">
           <h1>Serva</h1>
-          <p className="login-subtitle">Master-Anmeldung</p>
-          <form onSubmit={handleSubmit}>
-            <div className="form-group">
-              <label className="form-label" htmlFor="username">Benutzername</label>
-              <input id="username" className="form-input" type="text" autoComplete="username"
-                value={username} onChange={(e) => setUsername(e.target.value)} required />
-            </div>
-            <div className="form-group">
-              <label className="form-label" htmlFor="password">Passwort</label>
-              <input id="password" className="form-input" type="password" autoComplete="current-password"
-                value={password} onChange={(e) => setPassword(e.target.value)} required />
-            </div>
-            {error && <p className="form-error">{error}</p>}
-            <button className="btn-primary" type="submit" disabled={isLoggingIn}>
-              {isLoggingIn ? "Anmelden..." : "Anmelden"}
-            </button>
-          </form>
+          {configured ? (
+            <>
+              <p className="login-subtitle">Master-Anmeldung</p>
+              <form onSubmit={handleLogin}>
+                <div className="form-group">
+                  <label className="form-label" htmlFor="username">Benutzername</label>
+                  <input id="username" className="form-input" type="text" autoComplete="username"
+                    value={username} onChange={(e) => setUsername(e.target.value)} required />
+                </div>
+                <div className="form-group">
+                  <label className="form-label" htmlFor="password">Passwort</label>
+                  <input id="password" className="form-input" type="password" autoComplete="current-password"
+                    value={password} onChange={(e) => setPassword(e.target.value)} required />
+                </div>
+                {error && <p className="form-error">{error}</p>}
+                <button className="btn-primary" type="submit" disabled={isLoggingIn}>
+                  {isLoggingIn ? "Anmelden..." : "Anmelden"}
+                </button>
+              </form>
+            </>
+          ) : (
+            <>
+              <p className="login-subtitle">Ersteinrichtung — Master-Konto anlegen</p>
+              <form onSubmit={handleSetup}>
+                <div className="form-group">
+                  <label className="form-label" htmlFor="username">Benutzername</label>
+                  <input id="username" className="form-input" type="text" autoComplete="username"
+                    value={username} onChange={(e) => setUsername(e.target.value)} required />
+                </div>
+                <div className="form-group">
+                  <label className="form-label" htmlFor="password">Passwort (mind. 8 Zeichen)</label>
+                  <input id="password" className="form-input" type="password" autoComplete="new-password"
+                    value={password} onChange={(e) => setPassword(e.target.value)} required />
+                </div>
+                <div className="form-group">
+                  <label className="form-label" htmlFor="confirmPassword">Passwort bestätigen</label>
+                  <input id="confirmPassword" className="form-input" type="password" autoComplete="new-password"
+                    value={confirmPassword} onChange={(e) => setConfirmPassword(e.target.value)} required />
+                </div>
+                {error && <p className="form-error">{error}</p>}
+                <button className="btn-primary" type="submit" disabled={submitting || isLoggingIn}>
+                  {submitting ? "Konto wird angelegt..." : "Master-Konto anlegen"}
+                </button>
+              </form>
+            </>
+          )}
         </div>
       </div>
     </div>

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,6 +7,8 @@
   "scripts": {
     "dev": "tsx src/index.ts",
     "build": "tsc",
+    "build:bundle": "node scripts/build-bundle.mjs",
+    "build:runtime": "node scripts/build-runtime.mjs",
     "start": "node dist/index.js",
     "gen-cert": "tsx scripts/gen-cert.ts",
     "test": "tsx --test --test-concurrency=1 src/**/*.test.ts"
@@ -39,6 +41,7 @@
     "@types/node": "^24.12.2",
     "@types/qrcode": "^1.5.5",
     "@types/selfsigned": "^2.1.0",
+    "esbuild": "^0.28.0",
     "prisma": "^7.6.0",
     "tsx": "^4.21.0",
     "typescript": "~6.0.2"

--- a/apps/api/scripts/build-bundle.mjs
+++ b/apps/api/scripts/build-bundle.mjs
@@ -1,0 +1,40 @@
+// Bundles the Fastify API into a single ESM file so it can run under a private
+// Node runtime inside the Tauri app — no system Node, no source tree needed.
+//
+// Everything is inlined EXCEPT:
+//   - better-sqlite3      → native .node addon, cannot be bundled; shipped in
+//                           node_modules alongside the bundle.
+//   - @fastify/swagger-ui → loads its static UI assets from disk at runtime,
+//                           so it must keep its real package layout.
+// Those externals are copied next to the bundle by build-runtime.mjs.
+
+import { build } from "esbuild";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const apiRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+
+await build({
+  entryPoints: [join(apiRoot, "src/index.ts")],
+  bundle: true,
+  platform: "node",
+  format: "esm",
+  target: "node22",
+  outfile: join(apiRoot, "build/server.mjs"),
+  external: ["better-sqlite3", "@fastify/swagger-ui"],
+  // ESM output needs CJS interop shims for dependencies that reach for
+  // require()/__dirname/__filename at runtime.
+  banner: {
+    js: [
+      "import { createRequire as __serva_cr } from 'node:module';",
+      "import { fileURLToPath as __serva_fu } from 'node:url';",
+      "import { dirname as __serva_dn } from 'node:path';",
+      "const require = __serva_cr(import.meta.url);",
+      "const __filename = __serva_fu(import.meta.url);",
+      "const __dirname = __serva_dn(__filename);",
+    ].join("\n"),
+  },
+  logLevel: "info",
+});
+
+console.log("Bundled API → apps/api/build/server.mjs");

--- a/apps/api/scripts/build-runtime.mjs
+++ b/apps/api/scripts/build-runtime.mjs
@@ -1,0 +1,83 @@
+// Assembles a self-contained API runtime that the Tauri app ships and launches
+// — no system Node, no source tree required on the target machine.
+//
+// Output: apps/admin-desktop/src-tauri/resources/
+//   api/
+//     node.exe        ← private Node runtime (copied from the build machine)
+//     server.mjs      ← the esbuild bundle (all JS deps inlined)
+//     node_modules/   ← portable install of the non-bundlable externals
+//                       (better-sqlite3 native addon + @fastify/swagger-ui assets)
+//   waiter/           ← waiter-web production build, served by the API at /waiter
+//
+// tauri.conf.json copies both folders into the app's resource dir; lib.rs spawns
+// `api/node.exe api/server.mjs` with WAITER_DIST_PATH pointed at `waiter/`.
+
+import {
+  rmSync,
+  mkdirSync,
+  mkdtempSync,
+  cpSync,
+  copyFileSync,
+  writeFileSync,
+  readFileSync,
+} from "node:fs";
+import { join, dirname } from "node:path";
+import { tmpdir } from "node:os";
+import { fileURLToPath } from "node:url";
+import { execSync } from "node:child_process";
+
+const apiRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+const repoRoot = join(apiRoot, "..", "..");
+const resDir = join(repoRoot, "apps", "admin-desktop", "src-tauri", "resources");
+const apiOut = join(resDir, "api");
+const waiterOut = join(resDir, "waiter");
+
+const installedVersion = (pkg) =>
+  JSON.parse(readFileSync(join(apiRoot, "node_modules", pkg, "package.json"), "utf8")).version;
+
+const run = (cmd, cwd) => execSync(cmd, { cwd, stdio: "inherit" });
+
+// 1. Fresh staging dir
+rmSync(resDir, { recursive: true, force: true });
+mkdirSync(apiOut, { recursive: true });
+
+// 2. Bundle the API and copy it in
+run("node scripts/build-bundle.mjs", apiRoot);
+copyFileSync(join(apiRoot, "build", "server.mjs"), join(apiOut, "server.mjs"));
+
+// 3. Portable install of the externals that can't be bundled. A clean `npm
+//    install` produces a flat, copy-safe node_modules (unlike pnpm's symlinks)
+//    and fetches/builds the better-sqlite3 native binary for this platform.
+//    It MUST run outside the repo: the root package.json has an npm-style
+//    "workspaces" field, so npm run anywhere inside the tree would treat it as
+//    a workspace root and clobber pnpm's node_modules. Install in an OS temp
+//    dir, then copy the result into staging.
+const runtimePkg = {
+  name: "serva-api-runtime",
+  private: true,
+  version: "1.0.0",
+  dependencies: {
+    "better-sqlite3": installedVersion("better-sqlite3"),
+    "@fastify/swagger-ui": installedVersion("@fastify/swagger-ui"),
+  },
+};
+const tmp = mkdtempSync(join(tmpdir(), "serva-api-deps-"));
+try {
+  writeFileSync(join(tmp, "package.json"), JSON.stringify(runtimePkg, null, 2));
+  run("npm install --omit=dev --no-audit --no-fund --no-package-lock --no-workspaces", tmp);
+  cpSync(join(tmp, "node_modules"), join(apiOut, "node_modules"), { recursive: true });
+} finally {
+  rmSync(tmp, { recursive: true, force: true });
+}
+writeFileSync(join(apiOut, "package.json"), JSON.stringify(runtimePkg, null, 2));
+
+// 4. Private Node runtime (same version/arch as the build machine)
+copyFileSync(process.execPath, join(apiOut, "node.exe"));
+
+// 5. waiter-web production build → resources/waiter. Use `exec vite build`
+//    (not the package's `build` script) to mirror the root build:server path —
+//    waiter-web's `tsc -b` step is skipped there too.
+run("pnpm --filter waiter-web exec vite build", repoRoot);
+cpSync(join(repoRoot, "apps", "waiter-web", "dist"), waiterOut, { recursive: true });
+
+console.log(`\nAPI runtime staged at ${resDir}`);

--- a/apps/api/src/domain/auth-store.ts
+++ b/apps/api/src/domain/auth-store.ts
@@ -1,21 +1,51 @@
 ﻿import { ApiError } from "./api-error";
 import { EventStore } from "./event-store";
+import { MasterCredentialsStore } from "./master-credentials-store";
 import type { UserStore } from "./user-store";
 
 export class AuthStore {
   constructor(
     private readonly eventStore: EventStore,
-    private readonly userStore: UserStore
+    private readonly userStore: UserStore,
+    private readonly masterCredentials = new MasterCredentialsStore()
   ) {}
 
+  /**
+   * Master credentials come from MASTER_USERNAME/MASTER_PASSWORD env vars when
+   * set (dev, tests, advanced deployments). Otherwise the bundled desktop app
+   * uses the file-backed store the operator populates via first-run setup.
+   */
+  private masterEnvConfigured(): boolean {
+    return Boolean(process.env.MASTER_USERNAME && process.env.MASTER_PASSWORD);
+  }
+
+  isMasterConfigured(): boolean {
+    return this.masterEnvConfigured() || this.masterCredentials.hasCredentials();
+  }
+
+  setupMaster(input: { username: string; password: string }) {
+    if (this.isMasterConfigured()) {
+      throw new ApiError(409, "MASTER_ALREADY_CONFIGURED", "Master credentials are already configured");
+    }
+    this.masterCredentials.create(input.username, input.password);
+  }
+
   authenticateMaster(input: { username: string; password: string }) {
-    const masterUsername = process.env.MASTER_USERNAME;
-    const masterPassword = process.env.MASTER_PASSWORD;
-    if (!masterUsername || !masterPassword) {
+    if (this.masterEnvConfigured()) {
+      if (
+        input.username !== process.env.MASTER_USERNAME ||
+        input.password !== process.env.MASTER_PASSWORD
+      ) {
+        throw new ApiError(401, "UNAUTHORIZED", "Invalid master credentials");
+      }
+      return;
+    }
+
+    if (!this.masterCredentials.hasCredentials()) {
       throw new ApiError(500, "MASTER_AUTH_NOT_CONFIGURED", "Master credentials are not configured");
     }
 
-    if (input.username !== masterUsername || input.password !== masterPassword) {
+    if (!this.masterCredentials.verify(input.username, input.password)) {
       throw new ApiError(401, "UNAUTHORIZED", "Invalid master credentials");
     }
   }

--- a/apps/api/src/domain/master-credentials-store.ts
+++ b/apps/api/src/domain/master-credentials-store.ts
@@ -1,0 +1,57 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { resolve, join, dirname } from "node:path";
+import { randomBytes, scryptSync, timingSafeEqual } from "node:crypto";
+
+/**
+ * File-backed master credentials for the bundled desktop app, which ships with
+ * no MASTER_* env vars. The operator sets them once via the first-run setup
+ * screen; the password is stored only as a scrypt hash (never plaintext).
+ *
+ * In dev/tests the MASTER_USERNAME/MASTER_PASSWORD env vars take precedence and
+ * this store is never touched — see AuthStore.
+ */
+interface StoredCredentials {
+  username: string;
+  salt: string; // hex
+  hash: string; // hex
+}
+
+const KEY_LEN = 64;
+
+export class MasterCredentialsStore {
+  private readonly filePath: string;
+
+  constructor(baseDir = resolve(process.cwd(), "data")) {
+    this.filePath = join(baseDir, "master-credentials.json");
+  }
+
+  hasCredentials(): boolean {
+    return existsSync(this.filePath);
+  }
+
+  create(username: string, password: string): void {
+    const salt = randomBytes(16);
+    const hash = scryptSync(password, salt, KEY_LEN);
+    const record: StoredCredentials = {
+      username,
+      salt: salt.toString("hex"),
+      hash: hash.toString("hex"),
+    };
+    mkdirSync(dirname(this.filePath), { recursive: true });
+    writeFileSync(this.filePath, JSON.stringify(record, null, 2));
+  }
+
+  verify(username: string, password: string): boolean {
+    if (!this.hasCredentials()) return false;
+    let record: StoredCredentials;
+    try {
+      record = JSON.parse(readFileSync(this.filePath, "utf8")) as StoredCredentials;
+    } catch {
+      return false;
+    }
+    if (record.username !== username) return false;
+    const expected = Buffer.from(record.hash, "hex");
+    const actual = scryptSync(password, Buffer.from(record.salt, "hex"), KEY_LEN);
+    return expected.length === actual.length && timingSafeEqual(expected, actual);
+  }
+}

--- a/apps/api/src/routes/auth.ts
+++ b/apps/api/src/routes/auth.ts
@@ -10,6 +10,10 @@
   MasterSessionStartRequest,
   MasterSessionStartRequestSchema,
   MasterSessionStartResponseSchema,
+  MasterSetupRequest,
+  MasterSetupRequestSchema,
+  MasterSetupResponseSchema,
+  MasterStatusResponseSchema,
 } from "@serva/shared-types";
 import type { FastifyInstance } from "fastify";
 import { authStore } from "../domain/state";
@@ -17,6 +21,48 @@ import { authStore } from "../domain/state";
 const TOKEN_TTL_SECONDS = 60 * 60;
 
 export function registerAuthRoutes(app: FastifyInstance) {
+  app.get(
+    "/auth/master/status",
+    {
+      schema: {
+        tags: ["auth"],
+        operationId: "authMasterStatus",
+        summary: "Master-Konfigurationsstatus",
+        description:
+          "Meldet, ob Master-Zugangsdaten konfiguriert sind. Wenn nicht, zeigt die App einen Ersteinrichtungs-Bildschirm.",
+        security: [],
+        response: {
+          200: MasterStatusResponseSchema,
+        },
+      },
+    },
+    async () => ({ configured: authStore.isMasterConfigured() })
+  );
+
+  app.post<{ Body: MasterSetupRequest }>(
+    "/auth/master/setup",
+    {
+      schema: {
+        tags: ["auth"],
+        operationId: "authMasterSetup",
+        summary: "Master-Ersteinrichtung",
+        description:
+          "Legt einmalig die Master-Zugangsdaten an, solange noch keine konfiguriert sind. Beispiel-Body: { username: 'master', password: 'mind-8-zeichen' }",
+        security: [],
+        body: MasterSetupRequestSchema,
+        response: {
+          200: MasterSetupResponseSchema,
+          400: ApiErrorEnvelopeSchema,
+          409: ApiErrorEnvelopeSchema,
+        },
+      },
+    },
+    async (request) => {
+      authStore.setupMaster(request.body);
+      return { configured: true as const };
+    }
+  );
+
   app.post<{ Body: MasterSessionStartRequest }>(
     "/auth/master/login",
     {

--- a/apps/waiter-web/package.json
+++ b/apps/waiter-web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "waiter-web",
   "private": true,
-  "version": "0.0.0",
+  "version": "1.0.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -1,12 +1,13 @@
-﻿{
+{
   "name": "serva",
   "private": true,
-  "version": "0.1.0",
+  "version": "1.0.0",
   "workspaces": ["apps/*", "packages/*"],
   "scripts": {
     "dev": "pnpm -r --parallel dev",
-    "build": "pnpm -r build",
+    "build": "pnpm version:sync && pnpm -r build",
     "build:server": "pnpm --filter @serva/shared-types --filter @serva/api-client --filter @serva/auth-context build && pnpm --filter waiter-web exec vite build",
-    "tauri:build": "pnpm build:server && pnpm --filter appsadmin-desktop tauri build"
+    "tauri:build": "pnpm version:sync && pnpm build:server && pnpm --filter api build:runtime && pnpm --filter appsadmin-desktop tauri build",
+    "version:sync": "node scripts/sync-versions.mjs"
   }
 }

--- a/packages/api-client/src/routes/auth.ts
+++ b/packages/api-client/src/routes/auth.ts
@@ -3,6 +3,8 @@ import {
   AuthLoginResponseSchema,
   AuthMeResponseSchema,
   MasterSessionStartResponseSchema,
+  MasterSetupResponseSchema,
+  MasterStatusResponseSchema,
 } from "@serva/shared-types";
 import type {
   AdminSessionStartRequest,
@@ -12,10 +14,15 @@ import type {
   AuthMeResponse,
   MasterSessionStartRequest,
   MasterSessionStartResponse,
+  MasterSetupRequest,
+  MasterSetupResponse,
+  MasterStatusResponse,
 } from "@serva/shared-types";
 import type { HttpTransport } from "../http.js";
 
 export interface AuthClient {
+  masterStatus(): Promise<MasterStatusResponse>;
+  masterSetup(body: MasterSetupRequest): Promise<MasterSetupResponse>;
   loginMaster(body: MasterSessionStartRequest): Promise<MasterSessionStartResponse>;
   loginAdmin(body: AdminSessionStartRequest): Promise<AdminSessionStartResponse>;
   loginWaiter(body: AuthLoginRequest): Promise<AuthLoginResponse>;
@@ -24,6 +31,12 @@ export interface AuthClient {
 
 export function createAuthClient(http: HttpTransport): AuthClient {
   return {
+    masterStatus: () =>
+      http.get(MasterStatusResponseSchema, "/auth/master/status"),
+
+    masterSetup: (body) =>
+      http.post(MasterSetupResponseSchema, "/auth/master/setup", body),
+
     loginMaster: (body) =>
       http.post(MasterSessionStartResponseSchema, "/auth/master/login", body),
 

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -785,6 +785,31 @@ export const MasterSessionStartResponseSchema = z
   .strict();
 export type MasterSessionStartResponse = z.infer<typeof MasterSessionStartResponseSchema>;
 
+// First-run master setup. When the API has no master credentials configured
+// (no MASTER_* env vars and no stored credentials file), the desktop app shows
+// a setup screen that POSTs to /auth/master/setup once to create them.
+export const MasterStatusResponseSchema = z
+  .object({
+    configured: z.boolean(),
+  })
+  .strict();
+export type MasterStatusResponse = z.infer<typeof MasterStatusResponseSchema>;
+
+export const MasterSetupRequestSchema = z
+  .object({
+    username: nonEmptyString,
+    password: z.string().min(8),
+  })
+  .strict();
+export type MasterSetupRequest = z.infer<typeof MasterSetupRequestSchema>;
+
+export const MasterSetupResponseSchema = z
+  .object({
+    configured: z.literal(true),
+  })
+  .strict();
+export type MasterSetupResponse = z.infer<typeof MasterSetupResponseSchema>;
+
 export const TableQrResolveRequestSchema = z
   .object({
     qrValue: nonEmptyString,

--- a/scripts/sync-versions.mjs
+++ b/scripts/sync-versions.mjs
@@ -1,0 +1,51 @@
+// Single source of truth for the version is the root package.json.
+// This script copies that version into every workspace package.json and the
+// Tauri Rust crate (Cargo.toml). The desktop installer/app version is read
+// directly from the root package.json by tauri.conf.json, so this script only
+// keeps the *other* manifests aligned. Run it via `pnpm version:sync`; it is
+// also run automatically before `pnpm build` and `pnpm tauri:build`.
+//
+// To cut a release: bump "version" in the root package.json, nothing else.
+
+import { readFileSync, writeFileSync, readdirSync, existsSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const readJson = (path) => readFileSync(path, "utf8").replace(/^﻿/, "");
+
+const root = join(dirname(fileURLToPath(import.meta.url)), "..");
+const { version } = JSON.parse(readJson(join(root, "package.json")));
+
+const updated = [];
+
+// Every apps/* and packages/* package.json
+for (const ws of ["apps", "packages"]) {
+  const base = join(root, ws);
+  if (!existsSync(base)) continue;
+  for (const name of readdirSync(base)) {
+    const pkgPath = join(base, name, "package.json");
+    if (!existsSync(pkgPath)) continue;
+    const pkg = JSON.parse(readJson(pkgPath));
+    if (pkg.version === version) continue;
+    pkg.version = version;
+    writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + "\n");
+    updated.push(`${ws}/${name}/package.json`);
+  }
+}
+
+// Tauri Rust crate — Cargo needs a version and cannot read JSON itself.
+const cargoPath = join(root, "apps", "admin-desktop", "src-tauri", "Cargo.toml");
+if (existsSync(cargoPath)) {
+  const cargo = readFileSync(cargoPath, "utf8");
+  const next = cargo.replace(/^version = ".*"$/m, `version = "${version}"`);
+  if (next !== cargo) {
+    writeFileSync(cargoPath, next);
+    updated.push("apps/admin-desktop/src-tauri/Cargo.toml");
+  }
+}
+
+console.log(
+  updated.length
+    ? `Synced version ${version} to:\n  ${updated.join("\n  ")}`
+    : `All manifests already at version ${version}`,
+);


### PR DESCRIPTION
## Summary
Bundles the API and waiter-web into the Tauri admin-desktop app so a single NSIS installer runs everything — **no Node or setup required on the target machine**.

### Bundling (Path B — standalone runtime)
- `build-bundle.mjs` — esbuild bundles the API into one ESM file (better-sqlite3 + swagger-ui kept external).
- `build-runtime.mjs` — stages a private `node.exe`, a portable `node_modules` (with the native better-sqlite3 binary), and the waiter-web build into `src-tauri/resources`.
- `lib.rs` — production launches the bundled `node.exe` with a writable app-data working dir; dev falls back to system node + tsx.
- `tauri.conf.json` — bundles `resources/api` + `resources/waiter`; **NSIS-only** target (WiX/MSI can't handle the large `node_modules` tree). `productName` → **Serva**.

### Single-source versioning
- Root `package.json` is the single source of truth; Tauri reads it directly and `scripts/sync-versions.mjs` propagates it to all manifests + `Cargo.toml`.

### Production secrets
- Generate + persist a private `JWT_SECRET` on first run (`lib.rs`, via `getrandom`).
- First-run master-credentials setup: scrypt-hashed file store (env still wins for dev/tests), `GET /auth/master/status` + `POST /auth/master/setup`, api-client methods, shared-types schemas, and a desktop setup screen.

## Verification
- Typecheck (API) + auth tests pass; env-based master path unchanged.
- File-backed master flow (status → setup → login → re-setup → validation) verified.
- Built exe verified end-to-end: setup → login → token; `jwt-secret` persisted; `master-credentials.json` hashed.
- Final installer `Serva_1.0.0_x64-setup.exe` (29 MB) builds.

## Notes
- Two pre-existing `menu`/`tables` "reject unauthorized" test failures are **not** introduced here (verified identical on stashed baseline) — a test-isolation issue tied to active-event guard ordering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)