### PR TITLE
Serva-116 fix(waiter-web): lift special request dialog above bottom nav

### DIFF
--- a/apps/waiter-web/src/index.css
+++ b/apps/waiter-web/src/index.css
@@ -2478,6 +2478,10 @@ body {
   align-items: flex-end;
   justify-content: center;
   padding: 16px;
+  /* Lift the dialog (and its action button) clear of the bottom nav and the
+     iOS home indicator so "Hinzufügen" stays reachable — same offset the
+     other bottom-anchored controls use. */
+  padding-bottom: calc(var(--nav-h) + env(safe-area-inset-bottom) + 16px);
 }
 
 .sr-dialog {


### PR DESCRIPTION
## Summary

Fixes #116. On mobile, the special-request dialog's "Hinzufügen" button was tucked behind the sticky bottom nav, making it nearly unreachable.

## Cause

`.sr-dialog-backdrop` anchors the dialog to the bottom of the viewport (`align-items: flex-end`) but only padded it with a flat `16px`, dropping the footer button into the same vertical band as the 60px sticky `.layout-nav` (plus the iOS home indicator).

## Fix

Clear the nav and safe area with the same offset the other bottom-anchored controls (`.order-actions`, `.next-cta`) already use:

```css
padding-bottom: calc(var(--nav-h) + env(safe-area-inset-bottom) + 16px);
```

The dialog and its action button now sit above the nav.

## Acceptance criteria
- [x] The waiter can easily reach and tap the special-request action button.

🤖 Generated with [Claude Code](https://claude.com/claude-code)