### PR TITLE
Serva-122 fix(admin-desktop): keep master login working after app update

### DIFF
--- a/apps/admin-desktop/src-tauri/src/lib.rs
+++ b/apps/admin-desktop/src-tauri/src/lib.rs
@@ -89,6 +89,64 @@ fn ensure_jwt_secret(app: &tauri::AppHandle) -> Option<String> {
     Some(secret)
 }
 
+/// Path to the file recording the spawned API's PID, kept in the app-data dir.
+/// app-data is keyed by the bundle *identifier* (unchanged across the product
+/// rename), so a freshly-installed version can still find — and stop — an API
+/// left running by an older install that lives under a different productName.
+fn api_pid_path(app: &tauri::AppHandle) -> Option<PathBuf> {
+    let dir = app.path().app_data_dir().ok()?;
+    let _ = std::fs::create_dir_all(&dir);
+    Some(dir.join("api.pid"))
+}
+
+/// Forcibly terminates `pid` if — and only if — it is a Node process. The
+/// image-name check guards against killing an unrelated process that reused the
+/// PID after the previous API exited.
+#[cfg(target_os = "windows")]
+fn kill_node_pid(pid: u32) {
+    let is_node = Command::new("tasklist")
+        .args(["/FI", &format!("PID eq {pid}"), "/FO", "CSV", "/NH"])
+        .creation_flags(CREATE_NO_WINDOW)
+        .output()
+        .map(|o| {
+            String::from_utf8_lossy(&o.stdout)
+                .to_ascii_lowercase()
+                .contains("node.exe")
+        })
+        .unwrap_or(false);
+    if is_node {
+        let _ = Command::new("taskkill")
+            .args(["/F", "/T", "/PID", &pid.to_string()])
+            .creation_flags(CREATE_NO_WINDOW)
+            .output();
+    }
+}
+
+#[cfg(not(target_os = "windows"))]
+fn kill_node_pid(pid: u32) {
+    // Best-effort on non-Windows targets (dev only; the shipped bundle is Windows).
+    let _ = Command::new("kill").arg(pid.to_string()).output();
+}
+
+/// Stops an API process recorded by a previous app instance, if it's still
+/// alive, so the API we're about to spawn can bind its port. This matters after
+/// the `appsadmin-desktop` → `Serva` product rename: the new installer lays down
+/// a side-by-side install instead of upgrading in place, which can leave the old
+/// version's API holding port 8787. Without this, the new frontend would
+/// silently connect to the stale API (and, after a JWT-secret change, reject the
+/// operator's master login).
+fn terminate_previous_api(app: &tauri::AppHandle) {
+    let Some(pid_path) = api_pid_path(app) else {
+        return;
+    };
+    if let Ok(contents) = std::fs::read_to_string(&pid_path) {
+        if let Ok(pid) = contents.trim().parse::<u32>() {
+            kill_node_pid(pid);
+        }
+    }
+    let _ = std::fs::remove_file(&pid_path);
+}
+
 /// Resolves how to launch the API. Lookup order:
 ///   1. Bundled runtime in the Tauri resource dir (`api/node.exe`,
 ///      `api/server.mjs`, `waiter/`) — the shipped, self-contained path.
@@ -169,6 +227,10 @@ fn spawn_api(app: &tauri::AppHandle) -> Result<Option<Child>, std::io::Error> {
         return Ok(None);
     };
 
+    // Kill any API left running by a previous install/version before we try to
+    // bind the same port (see terminate_previous_api).
+    terminate_previous_api(app);
+
     let mut cmd = Command::new(&target.program);
     cmd.args(&target.args)
         .current_dir(&target.cwd)
@@ -210,6 +272,13 @@ fn spawn_api(app: &tauri::AppHandle) -> Result<Option<Child>, std::io::Error> {
         target.waiter_dist.display()
     );
     let child = cmd.spawn()?;
+
+    // Record the PID so the next launch can stop this API if it outlives us
+    // (e.g. an unclean shutdown, or a side-by-side install after a rename).
+    if let Some(pid_path) = api_pid_path(app) {
+        let _ = std::fs::write(pid_path, child.id().to_string());
+    }
+
     Ok(Some(child))
 }
 
@@ -248,6 +317,10 @@ pub fn run() {
                 if let Some(mut child) = taken {
                     let _ = child.kill();
                     let _ = child.wait();
+                }
+                // Drop the stale PID record now that the API is gone.
+                if let Some(pid_path) = api_pid_path(window.app_handle()) {
+                    let _ = std::fs::remove_file(pid_path);
                 }
             }
         })

--- a/packages/auth-context/src/auth-context.tsx
+++ b/packages/auth-context/src/auth-context.tsx
@@ -142,8 +142,15 @@ export function AuthProvider({
         setUser(principal.user ?? null);
       })
       .catch(() => {
-        // Token expired or invalid — clean up silently
+        // Token rejected — expired, or signed with a previous JWT secret after
+        // an app update. Clear both storage and in-memory state so the app
+        // always falls back to the login screen instead of wedging on a stale
+        // session; a fresh login then works regardless of the secret change.
         tokenStorage.removeToken();
+        setTokenState(null);
+        setRole(null);
+        setEventId(null);
+        setUser(null);
       })
       .finally(() => {
         setIsLoading(false);


### PR DESCRIPTION
Fixes the two defects behind #122 (master login breaking after a bundled-app update).

## Defect 1 — stale old-version API holding port 8787
The `appsadmin-desktop` → `Serva` `productName` rename makes the NSIS installer do a side-by-side install instead of an in-place upgrade, so an old API can keep holding port 8787. The new API then fails to bind (`EADDRINUSE`) and the frontend silently talks to the stale one.

`apps/admin-desktop/src-tauri/src/lib.rs` now terminates the previously-spawned API before starting a new one:
- `api_pid_path` records the API PID under `app_data_dir()` (keyed by the bundle **identifier**, unchanged across the rename, so a new install can find an old install's API).
- `terminate_previous_api` stops the recorded PID before spawning.
- `kill_node_pid` verifies the PID is `node.exe` (`tasklist`) before `taskkill /F /T` on Windows, guarding against a reused PID.
- The new PID is written after spawn and removed on graceful shutdown.

## Defect 2 — JWT-secret change blocking login
`packages/auth-context/src/auth-context.tsx`: the token-rehydration `.catch` now clears in-memory auth state (not just storage), so a token rejected after a JWT-secret change forces a clean re-login instead of wedging a stale session.

## Notes
- `productName` deliberately kept as `Serva` — renaming again would just cause another side-by-side install.
- **Still needs verification on a real upgrade** (the bug only reproduces against an installed prior version) — repro steps are in #122.

Closes #122

🤖 Generated with [Claude Code](https://claude.com/claude-code)