### PR TITLE
Serva-124 fix(api): cap self-signed cert validity at 397 days for iOS

### DIFF
--- a/.idea/encodings.xml
+++ b/.idea/encodings.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="Encoding" addBOMForNewFiles="with BOM under Windows, with no BOM otherwise">
+    <file url="file://$PROJECT_DIR$/packages/shared-types/package.json" charset="ISO-8859-1" />
     <file url="file://$PROJECT_DIR$/pnpm-workspace.yaml" charset="ISO-8859-1" />
   </component>
 </project>

--- a/apps/admin-desktop/package.json
+++ b/apps/admin-desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "appsadmin-desktop",
   "private": true,
-  "version": "1.0.1",
+  "version": "1.0.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/apps/admin-desktop/src-tauri/Cargo.toml
+++ b/apps/admin-desktop/src-tauri/Cargo.toml
@@ -2,7 +2,7 @@
 name = "appsadmin-desktop"
 # Auto-synced from the root package.json by scripts/sync-versions.mjs.
 # Do not edit by hand — bump "version" in the root package.json instead.
-version = "1.0.1"
+version = "1.0.2"
 description = "Desktop App for Serva"
 authors = ["Elias Pöschl (@DeltaAT)"]
 edition = "2021"

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "api",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "",
   "main": "index.js",
   "type": "module",

--- a/apps/api/scripts/gen-cert.ts
+++ b/apps/api/scripts/gen-cert.ts
@@ -25,7 +25,13 @@ const altNames = [
 
 const notBeforeDate = new Date();
 const notAfterDate = new Date();
-notAfterDate.setDate(notAfterDate.getDate() + 825);
+// Apple requires TLS server certificates issued on/after 2020-09-01 to have a
+// validity period of 398 days or fewer. iOS (Safari and Chrome) reject longer
+// certs during the handshake — surfaced as ERR_SSL_PROTOCOL_ERROR / "cannot
+// establish a secure connection" — even though desktop browsers only show a
+// click-through warning. Stay safely under the limit so phones can connect.
+// https://support.apple.com/en-us/HT211025
+notAfterDate.setDate(notAfterDate.getDate() + 397);
 
 const pems = await selfsigned.generate(
   [{ name: "commonName", value: "Serva Local" }],

--- a/apps/waiter-web/package.json
+++ b/apps/waiter-web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "waiter-web",
   "private": true,
-  "version": "1.0.1",
+  "version": "1.0.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "serva",
   "private": true,
-  "version": "1.0.1",
+  "version": "1.0.2",
   "workspaces": ["apps/*", "packages/*"],
   "scripts": {
     "dev": "pnpm -r --parallel dev",

--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@serva/api-client",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/auth-context/package.json
+++ b/packages/auth-context/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@serva/auth-context",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/shared-types/package.json
+++ b/packages/shared-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@serva/shared-types",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary
Fixes #124 — iPhones failed to open the waiter-web URL over HTTPS with `ERR_SSL_PROTOCOL_ERROR`.

The self-signed cert from `gen-cert.ts` was issued with an 825-day validity. Apple rejects TLS server certs valid for more than 398 days during the handshake (no click-through), while desktop/Android only show a bypassable warning. The cert is now issued for 397 days.

Also bumps all workspaces 1.0.1 -> 1.0.2.

## Notes
Regenerate the cert (`pnpm --filter api gen-cert`) and restart the API for the fix to take effect on existing installs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
