### PR TITLE
fix(api): export single-per-page QR PDFs in landscape

### DIFF
--- a/apps/api/src/routes/tables.test.ts
+++ b/apps/api/src/routes/tables.test.ts
@@ -219,6 +219,12 @@ test("admin CRUD and bulk table endpoints work", { concurrency: false }, async (
     (qrPdf as unknown as { rawPayload?: Buffer }).rawPayload ?? Buffer.from(qrPdf.body, "latin1");
   const qrPdfDoc = await PDFDocument.load(qrPdfBytes);
   assert.equal(qrPdfDoc.getPages().length, 2, "Expected default 2-up QR layout");
+  const defaultPage = qrPdfDoc.getPages()[0];
+  assert.equal(
+    defaultPage.getWidth() < defaultPage.getHeight(),
+    true,
+    "Expected default 2-up layout to stay portrait"
+  );
 
   const qrPdfSingleLayout = await app.inject({
     method: "GET",
@@ -231,6 +237,12 @@ test("admin CRUD and bulk table endpoints work", { concurrency: false }, async (
     Buffer.from(qrPdfSingleLayout.body, "latin1");
   const qrPdfSingleDoc = await PDFDocument.load(qrPdfSingleBytes);
   assert.equal(qrPdfSingleDoc.getPages().length, 4, "Expected single layout to render one table per page");
+  const singlePage = qrPdfSingleDoc.getPages()[0];
+  assert.equal(
+    singlePage.getWidth() > singlePage.getHeight(),
+    true,
+    "Expected single layout to be landscape"
+  );
 
   const waiterToken = (await auth.loginWaiter({
     username: "crud-waiter",

--- a/apps/api/src/routes/tables.ts
+++ b/apps/api/src/routes/tables.ts
@@ -182,8 +182,11 @@ async function buildTablesQrPdf(
   const pdfDoc = await PDFDocument.create();
   const nameFont = await pdfDoc.embedFont(StandardFonts.HelveticaBold);
   const bodyFont = await pdfDoc.embedFont(StandardFonts.Helvetica);
-  const pageSize: [number, number] = [595.28, 841.89];
+  const portraitSize: [number, number] = [595.28, 841.89];
+  const landscapeSize: [number, number] = [841.89, 595.28];
   const layout = options.layout ?? "double";
+  // Single (one Tisch per page) is exported landscape; double stays portrait.
+  const pageSize: [number, number] = layout === "single" ? landscapeSize : portraitSize;
   const pagePadding = 18;
 
   if (tables.length === 0) {


### PR DESCRIPTION
## Summary
Fixes #126. The one-Tisch-per-page QR export (`/tables/qr.pdf?layout=single` and the per-table `/tables/:id/qr.pdf` download) was emitting A4 **portrait** pages. This switches the `single` layout to A4 **landscape** while keeping the two-per-page (`double`) layout portrait, per the acceptance criteria.

`renderTableSlot` already derives all geometry from `page.getWidth()/getHeight()`, so swapping the page dimensions for the single branch is the only change needed.

## Changes
- `apps/api/src/routes/tables.ts` — `buildTablesQrPdf` picks landscape `[841.89, 595.28]` for `single`, portrait `[595.28, 841.89]` for `double`.
- `apps/api/src/routes/tables.test.ts` — asserts single layout pages are landscape (w > h) and default 2-up pages stay portrait (w < h).

## Acceptance criteria
- [x] one-per-page exported horizontal (landscape)
- [x] two-per-page stays as is (portrait)

## Verification
- New orientation assertions pass; `pnpm build` (tsc) clean.
- Rendered the real single-layout PDF to confirm a genuine landscape page (841.89 × 595.28, rotation 0).

> Note: the admin-desktop app runs a separate bundled `server.mjs`; that local bundle was regenerated for manual testing but is gitignored and not part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)