### PR TITLE
chore(api): printer queue — retry offline bons on reconnect (#130)

### DIFF
--- a/apps/api/src/domain/print-queue-worker.ts
+++ b/apps/api/src/domain/print-queue-worker.ts
@@ -1,0 +1,56 @@
+import type { PrinterStore } from "./printer-store";
+
+// Minimal logger surface so we can pass Fastify's `app.log` without coupling to
+// its full type.
+type WorkerLogger = {
+  info: (msg: string) => void;
+  error: (obj: unknown, msg?: string) => void;
+};
+
+export interface PrintQueueWorkerOptions {
+  intervalMs?: number;
+  logger?: WorkerLogger;
+}
+
+/**
+ * Periodically drains the active event's print queue so bons that failed to
+ * print (printer offline) are delivered as soon as the printer comes back
+ * online — the core of issue #130.
+ *
+ * Ticks never overlap: a slow drain (many queued bons, slow printer) simply
+ * skips the next tick rather than piling up concurrent runs against the same
+ * SQLite file. Returns a stop function; the timer is `unref`'d so it never
+ * keeps the process alive on its own.
+ */
+export function startPrintQueueWorker(
+  printerStore: PrinterStore,
+  options: PrintQueueWorkerOptions = {}
+): () => void {
+  const intervalMs = options.intervalMs ?? 15000;
+  const logger = options.logger;
+  let running = false;
+
+  const tick = async () => {
+    if (running) return;
+    running = true;
+    try {
+      const result = await printerStore.processPrintQueue();
+      if (result.printed > 0) {
+        logger?.info(
+          `Print queue: delivered ${result.printed} queued bon(s), ${result.remaining} still pending`
+        );
+      }
+    } catch (error) {
+      logger?.error(error, "Print queue worker tick failed");
+    } finally {
+      running = false;
+    }
+  };
+
+  const timer = setInterval(() => {
+    void tick();
+  }, intervalMs);
+  timer.unref?.();
+
+  return () => clearInterval(timer);
+}

--- a/apps/api/src/domain/printer-store.ts
+++ b/apps/api/src/domain/printer-store.ts
@@ -35,6 +35,33 @@ type OrderItemRowForPrint = {
   printerConnectionDetails: string | null;
 };
 
+// The subset of an order item needed to render a bon — everything else in
+// OrderItemRowForPrint is routing metadata used before rendering.
+type BonItem = {
+  menuItemName: string;
+  quantity: number;
+  specialRequests: string;
+};
+
+// Self-contained snapshot persisted in PrintQueue.payload. Re-rendering from
+// this never touches the (possibly since-edited) order/menu tables.
+type PrintQueuePayload = {
+  printerName: string;
+  order: OrderRowForPrint;
+  items: BonItem[];
+};
+
+type PrintQueueRow = {
+  id: number;
+  orderId: number;
+  printerId: number;
+  printerName: string;
+  target: string;
+  payload: string;
+  itemCount: number;
+  attempts: number;
+};
+
 // Renders an ISO timestamp as HH:MM in the host's local time. The kitchen only
 // cares about wall-clock when the bon was placed, not the date.
 function formatTimeOnly(iso: string): string {
@@ -80,6 +107,7 @@ export class PrinterStore {
 
     const db = new Database(activeEvent.dbFilePath);
     this.ensurePrinterSchema(db);
+    this.ensurePrintQueueSchema(db);
     return db;
   }
 
@@ -93,6 +121,33 @@ export class PrinterStore {
       );
 
       CREATE UNIQUE INDEX IF NOT EXISTS Printers_name_key ON Printers(name);
+    `);
+  }
+
+  // Holds bons that could not be delivered because their printer was offline.
+  // `payload` is a self-contained JSON snapshot of the bon (see PrintQueuePayload)
+  // so a retry re-renders exactly what was ordered, independent of any later
+  // edits to the order. The UNIQUE(orderId, printerId) key means re-printing the
+  // same order while the printer is still down refreshes the pending job rather
+  // than stacking duplicates that would all fire at once on reconnect.
+  private ensurePrintQueueSchema(db: Database.Database) {
+    db.exec(`
+      CREATE TABLE IF NOT EXISTS PrintQueue (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        orderId INTEGER NOT NULL,
+        printerId INTEGER NOT NULL,
+        printerName TEXT NOT NULL,
+        target TEXT NOT NULL,
+        payload TEXT NOT NULL,
+        itemCount INTEGER NOT NULL DEFAULT 0,
+        attempts INTEGER NOT NULL DEFAULT 0,
+        lastError TEXT,
+        createdAt TEXT NOT NULL,
+        updatedAt TEXT NOT NULL
+      );
+
+      CREATE UNIQUE INDEX IF NOT EXISTS PrintQueue_order_printer_key
+        ON PrintQueue(orderId, printerId);
     `);
   }
 
@@ -436,29 +491,14 @@ export class PrinterStore {
 
         const port = this.getPort(group.printerConnectionDetails ?? "");
         const target = `${group.printerIpAddress}:${port}`;
-        const printer = this.createThermalPrinter(target);
 
         try {
-          const connected = await printer.isPrinterConnected();
-          if (!connected) {
-            throw new ApiError(
-              409,
-              "PRINTER_CONNECTION_FAILED",
-              `No response from printer '${group.printerName}' at ${target}.`,
-              {
-                target,
-                hint: "Check IP/port configuration and printer power/network state.",
-              }
-            );
-          }
-
-          this.formatOrderBon(printer, {
+          await this.printBon({
+            target,
             printerName: group.printerName,
             order,
             items: group.items,
           });
-
-          await printer.execute();
 
           results.push({
             printerId: group.printerId,
@@ -482,12 +522,25 @@ export class PrinterStore {
             | { target?: string; hint?: string }
             | undefined;
 
+          // Printer offline → don't drop the bon. Persist a self-contained
+          // snapshot to the queue so the background worker can print it once
+          // the printer is reachable again (issue #130).
+          this.enqueuePrintJob(db, {
+            orderId: order.id,
+            printerId: group.printerId,
+            printerName: group.printerName,
+            target,
+            itemCount,
+            payload: { printerName: group.printerName, order, items: group.items },
+            errorMessage: apiError.message,
+          });
+
           results.push({
             printerId: group.printerId,
             printerName: group.printerName,
-            status: "error",
+            status: "queued",
             itemCount,
-            message: apiError.message,
+            message: `Drucker '${group.printerName}' offline — Bon in Warteschlange, wird bei Wiederverbindung gedruckt.`,
             code: apiError.code,
             target: details?.target ?? target,
             hint: details?.hint,
@@ -526,12 +579,157 @@ export class PrinterStore {
     `);
   }
 
+  // Connects to a single printer and prints one bon. Throws an ApiError on any
+  // connection/execution failure so callers can decide whether to surface the
+  // error (interactive print) or enqueue for retry (queue worker).
+  private async printBon(input: {
+    target: string;
+    printerName: string;
+    order: OrderRowForPrint;
+    items: BonItem[];
+  }): Promise<void> {
+    const { target, printerName, order, items } = input;
+    const printer = this.createThermalPrinter(target);
+
+    let connected = false;
+    try {
+      connected = await printer.isPrinterConnected();
+    } catch (error) {
+      throw this.mapPrinterConnectionError({ error, printerName, target });
+    }
+
+    if (!connected) {
+      throw new ApiError(
+        409,
+        "PRINTER_CONNECTION_FAILED",
+        `No response from printer '${printerName}' at ${target}.`,
+        {
+          target,
+          hint: "Check IP/port configuration and printer power/network state.",
+        }
+      );
+    }
+
+    this.formatOrderBon(printer, { printerName, order, items });
+
+    try {
+      await printer.execute();
+    } catch (error) {
+      throw this.mapPrinterConnectionError({ error, printerName, target });
+    }
+  }
+
+  private enqueuePrintJob(
+    db: Database.Database,
+    input: {
+      orderId: number;
+      printerId: number;
+      printerName: string;
+      target: string;
+      itemCount: number;
+      payload: PrintQueuePayload;
+      errorMessage: string;
+    }
+  ) {
+    const now = new Date().toISOString();
+    db.prepare(
+      `
+      INSERT INTO PrintQueue
+        (orderId, printerId, printerName, target, payload, itemCount, attempts, lastError, createdAt, updatedAt)
+      VALUES
+        (@orderId, @printerId, @printerName, @target, @payload, @itemCount, 1, @lastError, @now, @now)
+      ON CONFLICT(orderId, printerId) DO UPDATE SET
+        printerName = excluded.printerName,
+        target = excluded.target,
+        payload = excluded.payload,
+        itemCount = excluded.itemCount,
+        attempts = PrintQueue.attempts + 1,
+        lastError = excluded.lastError,
+        updatedAt = excluded.updatedAt
+      `
+    ).run({
+      orderId: input.orderId,
+      printerId: input.printerId,
+      printerName: input.printerName,
+      target: input.target,
+      payload: JSON.stringify(input.payload),
+      itemCount: input.itemCount,
+      lastError: input.errorMessage,
+      now,
+    });
+  }
+
+  // Drains the active event's print queue: retries every pending bon, deleting
+  // the ones that print successfully and bumping the attempt counter on the
+  // rest. No-op when no event is active. Called on an interval by the print
+  // queue worker (see print-queue-worker.ts) and directly by tests.
+  async processPrintQueue(): Promise<{ printed: number; failed: number; remaining: number }> {
+    const activeEvent = this.eventStore.getActiveEvent();
+    if (!activeEvent) {
+      return { printed: 0, failed: 0, remaining: 0 };
+    }
+
+    const db = new Database(activeEvent.dbFilePath);
+    this.ensurePrintQueueSchema(db);
+    try {
+      const jobs = db
+        .prepare(
+          `
+          SELECT id, orderId, printerId, printerName, target, payload, itemCount, attempts
+          FROM PrintQueue
+          ORDER BY createdAt ASC, id ASC
+          `
+        )
+        .all() as PrintQueueRow[];
+
+      let printed = 0;
+      let failed = 0;
+
+      for (const job of jobs) {
+        let payload: PrintQueuePayload;
+        try {
+          payload = JSON.parse(job.payload) as PrintQueuePayload;
+        } catch {
+          // Unparseable payload can never succeed — drop it so it stops
+          // blocking the queue.
+          db.prepare("DELETE FROM PrintQueue WHERE id = ?").run(job.id);
+          continue;
+        }
+
+        try {
+          await this.printBon({
+            target: job.target,
+            printerName: payload.printerName,
+            order: payload.order,
+            items: payload.items,
+          });
+          db.prepare("DELETE FROM PrintQueue WHERE id = ?").run(job.id);
+          printed += 1;
+        } catch (error) {
+          failed += 1;
+          const reason = error instanceof Error ? error.message : String(error);
+          db.prepare(
+            "UPDATE PrintQueue SET attempts = attempts + 1, lastError = ?, updatedAt = ? WHERE id = ?"
+          ).run(reason, new Date().toISOString(), job.id);
+        }
+      }
+
+      const remaining = (
+        db.prepare("SELECT COUNT(*) as count FROM PrintQueue").get() as { count: number }
+      ).count;
+
+      return { printed, failed, remaining };
+    } finally {
+      db.close();
+    }
+  }
+
   private formatOrderBon(
     printer: ThermalPrinter,
     input: {
       printerName: string;
       order: OrderRowForPrint;
-      items: OrderItemRowForPrint[];
+      items: BonItem[];
     }
   ) {
     const { printerName, order, items } = input;

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -4,6 +4,8 @@ import https from "node:https";
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { buildApp } from "./app";
+import { startPrintQueueWorker } from "./domain/print-queue-worker";
+import { printerStore } from "./domain/state";
 import { ensureCert } from "./tls/ensure-cert";
 
 const port = Number(process.env.PORT || 8787);
@@ -70,3 +72,10 @@ if (httpsEnabled) {
 console.log(
   `Swagger UI available at http${httpsEnabled ? "s" : ""}://${host}:${httpsEnabled ? httpsPort : port}/documentation`,
 );
+
+// Retry offline-printer bons in the background: anything queued while a printer
+// was down is delivered automatically once it comes back online (issue #130).
+const stopPrintQueueWorker = startPrintQueueWorker(printerStore, { logger: app.log });
+app.addHook("onClose", async () => {
+  stopPrintQueueWorker();
+});

--- a/apps/api/src/routes/printers.test.ts
+++ b/apps/api/src/routes/printers.test.ts
@@ -3,7 +3,7 @@ import Database from "better-sqlite3";
 import net from "node:net";
 import test from "node:test";
 import { buildApp } from "../app";
-import { eventStore } from "../domain/state";
+import { eventStore, printerStore } from "../domain/state";
 import { setupEventTestUtils } from "../test-utils/event-test-utils";
 
 const { createTestEvent, createEventPrefix, createAppFixture, createAuthFixture } = setupEventTestUtils(
@@ -11,7 +11,7 @@ const { createTestEvent, createEventPrefix, createAppFixture, createAuthFixture 
   eventStore
 );
 
-async function createFakeThermalPrinterServer() {
+async function createFakeThermalPrinterServer(port = 0) {
   let receivedBytes = 0;
   let connections = 0;
   const server = net.createServer((socket) => {
@@ -23,7 +23,7 @@ async function createFakeThermalPrinterServer() {
 
   await new Promise<void>((resolve, reject) => {
     server.once("error", reject);
-    server.listen(0, "127.0.0.1", () => {
+    server.listen(port, "127.0.0.1", () => {
       server.off("error", reject);
       resolve();
     });
@@ -98,6 +98,74 @@ function seedMenuCategoryWithPrinter(dbFilePath: string, printerId: number) {
     "INSERT INTO MenuCategories (name, description, isLocked, weight, printer_id, orderDisplay_id) VALUES (?, ?, ?, ?, ?, NULL)"
   ).run("Kitchen", "", 0, 0, printerId);
   db.close();
+}
+
+// Seeds a minimal but complete order that routes to `printerId`, returning the
+// new order id. Mirrors the schema the printer store reads in printOrder.
+function seedPrintableOrder(dbFilePath: string, printerId: number): number {
+  const db = new Database(dbFilePath);
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS MenuCategories (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      name TEXT NOT NULL,
+      description TEXT NOT NULL DEFAULT '',
+      isLocked INTEGER NOT NULL DEFAULT 0,
+      weight INTEGER NOT NULL DEFAULT 0,
+      printer_id INTEGER,
+      orderDisplay_id INTEGER
+    );
+    CREATE TABLE IF NOT EXISTS MenuItems (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      name TEXT NOT NULL,
+      menuCategory_id INTEGER NOT NULL,
+      weight INTEGER NOT NULL DEFAULT 0
+    );
+    CREATE TABLE IF NOT EXISTS Orders (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      timestamp TEXT NOT NULL,
+      table_id INTEGER NOT NULL,
+      user_id INTEGER NOT NULL
+    );
+    CREATE TABLE IF NOT EXISTS OrderItems (
+      order_id INTEGER NOT NULL,
+      menuItem_id INTEGER NOT NULL,
+      quantity INTEGER NOT NULL,
+      specialRequests TEXT NOT NULL DEFAULT '',
+      PRIMARY KEY (order_id, menuItem_id)
+    );
+    CREATE TABLE IF NOT EXISTS Tables (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      name TEXT NOT NULL
+    );
+    CREATE TABLE IF NOT EXISTS Users (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      username TEXT NOT NULL
+    );
+  `);
+
+  const categoryId = Number(
+    db
+      .prepare(
+        "INSERT INTO MenuCategories (name, description, isLocked, weight, printer_id, orderDisplay_id) VALUES (?, '', 0, 0, ?, NULL)"
+      )
+      .run("Kitchen", printerId).lastInsertRowid
+  );
+  const menuItemId = Number(
+    db
+      .prepare("INSERT INTO MenuItems (name, menuCategory_id, weight) VALUES (?, ?, 0)")
+      .run("Pommes", categoryId).lastInsertRowid
+  );
+  const orderId = Number(
+    db
+      .prepare("INSERT INTO Orders (timestamp, table_id, user_id) VALUES (?, 1, 1)")
+      .run(new Date().toISOString()).lastInsertRowid
+  );
+  db.prepare(
+    "INSERT INTO OrderItems (order_id, menuItem_id, quantity, specialRequests) VALUES (?, ?, ?, '')"
+  ).run(orderId, menuItemId, 2);
+  db.close();
+
+  return orderId;
 }
 
 test("printers endpoints reject unauthorized requests", { concurrency: false }, async () => {
@@ -331,5 +399,90 @@ test("test-print returns understandable connection errors", { concurrency: false
   assert.match(body.error.message, /Printer/);
   assert.match(body.error.details?.target ?? "", /127\.0\.0\.1:/);
   assert.ok((body.error.details?.hint ?? "").length > 0);
+});
+
+test("offline printer queues the bon and the worker prints it on reconnect", { concurrency: false }, async () => {
+  const closedPort = await reservePortAndClose();
+  const created = createTestEvent({
+    eventName: createEventPrefix("printer-queue"),
+    eventPasscode: "printer-queue-pass",
+    adminUsername: "chef",
+    adminPassword: "secret123",
+  });
+  eventStore.activateEvent(created.id);
+
+  const printer = printerStore.createPrinter({
+    name: "Kitchen",
+    ipAddress: "127.0.0.1",
+    connectionDetails: String(closedPort),
+  });
+  const orderId = seedPrintableOrder(created.dbFilePath, printer.id);
+
+  // Printer is offline → the bon must be queued, not lost.
+  const firstRun = await printerStore.printOrder(orderId);
+  const queuedResult = firstRun.results.find((r) => r.printerId === printer.id);
+  assert.equal(queuedResult?.status, "queued");
+
+  const pendingBefore = (() => {
+    const db = new Database(created.dbFilePath);
+    try {
+      return (db.prepare("SELECT COUNT(*) as count FROM PrintQueue").get() as { count: number })
+        .count;
+    } finally {
+      db.close();
+    }
+  })();
+  assert.equal(pendingBefore, 1);
+
+  // Printer comes back online on the same address → worker drains the queue.
+  const fakePrinter = await createFakeThermalPrinterServer(closedPort);
+  try {
+    const drain = await printerStore.processPrintQueue();
+    assert.equal(drain.printed, 1);
+    assert.equal(drain.remaining, 0);
+    assert.ok(
+      fakePrinter.getConnections() > 0,
+      "expected the queued bon to reach the printer on reconnect"
+    );
+  } finally {
+    await fakePrinter.close();
+  }
+
+  // Draining again is a no-op — the delivered bon is gone from the queue.
+  const secondDrain = await printerStore.processPrintQueue();
+  assert.equal(secondDrain.printed, 0);
+  assert.equal(secondDrain.remaining, 0);
+});
+
+test("re-printing an offline order does not stack duplicate queue entries", { concurrency: false }, async () => {
+  const closedPort = await reservePortAndClose();
+  const created = createTestEvent({
+    eventName: createEventPrefix("printer-queue-dedupe"),
+    eventPasscode: "printer-queue-dedupe-pass",
+    adminUsername: "chef",
+    adminPassword: "secret123",
+  });
+  eventStore.activateEvent(created.id);
+
+  const printer = printerStore.createPrinter({
+    name: "Kitchen",
+    ipAddress: "127.0.0.1",
+    connectionDetails: String(closedPort),
+  });
+  const orderId = seedPrintableOrder(created.dbFilePath, printer.id);
+
+  await printerStore.printOrder(orderId);
+  await printerStore.printOrder(orderId);
+
+  const db = new Database(created.dbFilePath);
+  try {
+    const row = db
+      .prepare("SELECT COUNT(*) as count, MAX(attempts) as attempts FROM PrintQueue WHERE orderId = ?")
+      .get(orderId) as { count: number; attempts: number };
+    assert.equal(row.count, 1);
+    assert.equal(row.attempts, 2);
+  } finally {
+    db.close();
+  }
 });
 

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -1005,12 +1005,16 @@ export type OrderGetResponse = OrderDto;
 // order's items by their menu category's assigned printer and sends one bon
 // per printer. The response carries a per-printer result so the waiter UI can
 // surface partial failures (one printer offline doesn't fail the whole run).
+//
+// `status: "queued"` means the printer was offline, so the bon was stored in
+// the per-event print queue and will be printed automatically once the printer
+// comes back online — nothing is lost.
 
 export const OrderPrintResultDtoSchema = z
   .object({
     printerId: positiveInt.optional(),
     printerName: z.string(),
-    status: z.enum(["ok", "error", "skipped"]),
+    status: z.enum(["ok", "error", "skipped", "queued"]),
     itemCount: z.number().int().nonnegative(),
     message: z.string(),
     code: z.string().optional(),


### PR DESCRIPTION
Closes #130

## What
Adds a print queue so bons are never lost when a printer is offline. When a print run hits an offline printer, the bon is persisted to a per-event `PrintQueue` table; a background worker retries delivery and prints queued bons as soon as the printer comes back online.

## Changes
- **`printer-store.ts`**: new `PrintQueue` table (self-contained JSON bon snapshot, `UNIQUE(orderId, printerId)` to avoid duplicates); extracted `printBon()` helper; `printOrder()` enqueues on connection failure and returns `status: "queued"`; new `processPrintQueue()` drains the active event's queue.
- **`print-queue-worker.ts`** (new): `startPrintQueueWorker()` runs the drain on an interval (non-overlapping ticks, `unref`'d timer, stop handle).
- **`index.ts`**: starts the worker on boot, stops on `onClose`.
- **`shared-types`**: adds `"queued"` to the `OrderPrintResultDto` status enum.

## Tests
Two new tests in `printers.test.ts`:
- offline → queued → worker prints on reconnect → queue drained
- re-printing an offline order does not stack duplicate queue entries

Printer suite passes 7/7; typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)