### PR TITLE
fix(api): tables bulk add order — new tables at the beginning (#138)

### DIFF
--- a/apps/api/src/domain/table-store.ts
+++ b/apps/api/src/domain/table-store.ts
@@ -150,10 +150,22 @@ export class TableStore {
         throw new ApiError(409, "TABLE_ALREADY_EXISTS", "Table names in request must be unique");
       }
 
+      // New tables go to the beginning of the list (lowest weight first), which
+      // means below every existing table's weight. Slotting them at a fixed
+      // 0..N-1 would collide with existing weights and scatter the batch once
+      // the list is re-sorted by (weight, name). We reserve the N slots just
+      // below the current minimum so the batch lands as a contiguous block at
+      // the top, in the order it was requested — and each subsequent bulk add
+      // stacks cleanly above the previous one. See issue #138.
+      const { minWeight } = db
+        .prepare("SELECT MIN(weight) AS minWeight FROM Tables")
+        .get() as { minWeight: number | null };
+      const baseWeight = (minWeight ?? 0) - names.length;
+
       const insert = db.prepare("INSERT INTO Tables (name, weight, isLocked) VALUES (?, ?, ?)");
       const transaction = db.transaction(() => {
         names.forEach((name, index) => {
-          insert.run(name, index, input.lockNew ? 1 : 0);
+          insert.run(name, baseWeight + index, input.lockNew ? 1 : 0);
         });
       });
 

--- a/apps/api/src/routes/tables.test.ts
+++ b/apps/api/src/routes/tables.test.ts
@@ -348,3 +348,72 @@ test("admin CRUD and bulk table endpoints work", { concurrency: false }, async (
 
 });
 
+test("bulk-created tables land at the beginning in request order across repeated adds", { concurrency: false }, async () => {
+  const adminPassword = "secret123";
+  const created = createTestEvent({
+    eventName: createEventPrefix("tables-bulk-order"),
+    eventPasscode: "tables-bulk-order-pass",
+    adminUsername: "chef",
+    adminPassword,
+  });
+  eventStore.activateEvent(created.id);
+
+  // Pre-existing tables, spaced like the admin UI's reorder scheme ((i+1)*10).
+  seedTables(created.dbFilePath, [
+    { name: "Existing1", weight: 10 },
+    { name: "Existing2", weight: 20 },
+  ]);
+
+  const app = await createAppFixture(buildApp);
+  const auth = createAuthFixture(app);
+  const adminToken = await auth.loginAdmin({
+    eventId: created.id,
+    username: "chef",
+    password: adminPassword,
+  });
+
+  const listNames = async () => {
+    const res = await app.inject({
+      method: "GET",
+      url: "/tables?sort=weight,name",
+      headers: { authorization: `Bearer ${adminToken}` },
+    });
+    assert.equal(res.statusCode, 200);
+    return (res.json() as { tables: Array<{ name: string }> }).tables.map((t) => t.name);
+  };
+
+  // First bulk add → the batch must appear as a contiguous block at the top,
+  // in the requested numeric order, ahead of the existing tables.
+  const firstBulk = await app.inject({
+    method: "POST",
+    url: "/tables/bulk",
+    headers: { authorization: `Bearer ${adminToken}` },
+    payload: { rows: ["A"], from: 1, to: 3 },
+  });
+  assert.equal(firstBulk.statusCode, 201);
+  assert.deepEqual(
+    (firstBulk.json() as { tables: Array<{ name: string }> }).tables.map((t) => t.name),
+    ["A1", "A2", "A3"]
+  );
+  assert.deepEqual(await listNames(), ["A1", "A2", "A3", "Existing1", "Existing2"]);
+
+  // Second bulk add stacks cleanly above the first — newest batch on top, still
+  // in request order, with no interleaving (issue #138).
+  const secondBulk = await app.inject({
+    method: "POST",
+    url: "/tables/bulk",
+    headers: { authorization: `Bearer ${adminToken}` },
+    payload: { rows: ["B"], from: 1, to: 2 },
+  });
+  assert.equal(secondBulk.statusCode, 201);
+  assert.deepEqual(await listNames(), [
+    "B1",
+    "B2",
+    "A1",
+    "A2",
+    "A3",
+    "Existing1",
+    "Existing2",
+  ]);
+});
+


### PR DESCRIPTION
Closes #138

## Problem
Bulk-adding tables when some already exist produced a scattered order: the new tables were not grouped at the beginning as expected.

## Cause
`createTablesBulk` assigned the new tables weights `0..N-1` regardless of existing tables' weights. On a second bulk add these collided with existing weights, and since the list sorts by `(weight, name)` the new batch interleaved with the old tables.

## Fix
The batch now takes the `N` weight slots just **below the current minimum** weight, so it lands as a contiguous block at the top in the requested numeric order. Repeated bulk adds stack cleanly, newest on top.

## Test
Added `bulk-created tables land at the beginning in request order across repeated adds` in `tables.test.ts`: seeds existing tables, does two bulk adds, and asserts the final order is `[B1, B2, A1, A2, A3, Existing1, Existing2]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)