### PR TITLE
feat(api/admin-desktop): import/export menu (#135)

### DIFF
--- a/apps/admin-desktop/src-tauri/capabilities/default.json
+++ b/apps/admin-desktop/src-tauri/capabilities/default.json
@@ -14,9 +14,19 @@
     "core:window:allow-start-dragging",
     "dialog:default",
     "dialog:allow-save",
+    "dialog:allow-open",
     "fs:default",
     {
       "identifier": "fs:allow-write-file",
+      "allow": [
+        { "path": "$HOME/**" },
+        { "path": "$DESKTOP/**" },
+        { "path": "$DOCUMENT/**" },
+        { "path": "$DOWNLOAD/**" }
+      ]
+    },
+    {
+      "identifier": "fs:allow-read-file",
       "allow": [
         { "path": "$HOME/**" },
         { "path": "$DESKTOP/**" },

--- a/apps/admin-desktop/src/lib/menu-file.ts
+++ b/apps/admin-desktop/src/lib/menu-file.ts
@@ -1,0 +1,73 @@
+import { isTauri } from "@tauri-apps/api/core";
+
+// Small cross-environment helpers for reading/writing a text file. In the
+// packaged desktop app these go through the Tauri dialog + fs plugins; during
+// `vite dev` (plain browser) they fall back to a download anchor / file input
+// so the flow stays testable outside Tauri.
+
+/** Saves `text` to a user-chosen path. Returns false if the user cancelled. */
+export async function saveTextFile(
+  defaultName: string,
+  text: string,
+  extension: string,
+): Promise<boolean> {
+  if (isTauri()) {
+    const { save } = await import("@tauri-apps/plugin-dialog");
+    const path = await save({
+      defaultPath: defaultName,
+      filters: [{ name: extension.toUpperCase(), extensions: [extension] }],
+    });
+    if (!path) return false;
+    const { writeTextFile } = await import("@tauri-apps/plugin-fs");
+    await writeTextFile(path, text);
+    return true;
+  }
+
+  // Browser fallback: trigger a download.
+  const blob = new Blob([text], { type: "application/json" });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = defaultName;
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+  URL.revokeObjectURL(url);
+  return true;
+}
+
+/** Prompts for a file and returns its text, or null if the user cancelled. */
+export async function openTextFile(extension: string): Promise<string | null> {
+  if (isTauri()) {
+    const { open } = await import("@tauri-apps/plugin-dialog");
+    const path = await open({
+      multiple: false,
+      directory: false,
+      filters: [{ name: extension.toUpperCase(), extensions: [extension] }],
+    });
+    if (!path || typeof path !== "string") return null;
+    const { readTextFile } = await import("@tauri-apps/plugin-fs");
+    return readTextFile(path);
+  }
+
+  // Browser fallback: a hidden <input type="file">.
+  return new Promise<string | null>((resolve) => {
+    const input = document.createElement("input");
+    input.type = "file";
+    input.accept = `.${extension}`;
+    input.onchange = () => {
+      const file = input.files?.[0];
+      if (!file) {
+        resolve(null);
+        return;
+      }
+      file
+        .text()
+        .then((t) => resolve(t))
+        .catch(() => resolve(null));
+    };
+    // If the picker is dismissed no change event fires; that just leaves the
+    // promise pending, which is harmless (the caller's flow simply ends).
+    input.click();
+  });
+}

--- a/apps/admin-desktop/src/pages/MenuPage.tsx
+++ b/apps/admin-desktop/src/pages/MenuPage.tsx
@@ -1,7 +1,9 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useApiClient } from "../contexts/ApiClientContext";
 import { ApiConflictError } from "@serva/api-client";
-import type { MenuCategoryDto, MenuItemDto, PrinterDto } from "@serva/shared-types";
+import { MenuExportSchema } from "@serva/shared-types";
+import type { MenuCategoryDto, MenuExport, MenuItemDto, PrinterDto } from "@serva/shared-types";
+import { openTextFile, saveTextFile } from "../lib/menu-file";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -293,6 +295,73 @@ function ItemDeleteModal({
 }
 
 // ---------------------------------------------------------------------------
+// ImportModal
+// ---------------------------------------------------------------------------
+
+function ImportModal({
+  menu,
+  onClose,
+  onConfirm,
+  importing,
+  error,
+}: {
+  menu: MenuExport;
+  onClose: () => void;
+  onConfirm: (mode: "merge" | "replace") => Promise<void>;
+  importing: boolean;
+  error: string | null;
+}) {
+  const [mode, setMode] = useState<"merge" | "replace">("merge");
+  const categoryCount = menu.categories.length;
+  const itemCount = menu.categories.reduce((sum, c) => sum + c.items.length, 0);
+
+  return (
+    <div className="modal-overlay" role="dialog" aria-modal="true"
+      onClick={(e) => { if (e.target === e.currentTarget && !importing) onClose(); }}>
+      <div className="modal-card" style={{ width: 460 }}>
+        <h3 className="modal-title">Speisekarte importieren</h3>
+        <p className="modal-subtitle">
+          Die Datei enthält <strong>{categoryCount}</strong> {categoryCount === 1 ? "Kategorie" : "Kategorien"} und{" "}
+          <strong>{itemCount}</strong> {itemCount === 1 ? "Artikel" : "Artikel"}.
+        </p>
+
+        <div className="form-group">
+          <label className="form-label">Modus</label>
+          <label className="cat-checkbox-label" style={{ alignItems: "flex-start" }}>
+            <input type="radio" name="import-mode" checked={mode === "merge"}
+              onChange={() => setMode("merge")} disabled={importing} />
+            <span>
+              <strong>Zusammenführen</strong> — vorhandene Kategorien/Artikel per Name aktualisieren, neue hinzufügen.
+            </span>
+          </label>
+          <label className="cat-checkbox-label" style={{ alignItems: "flex-start", marginTop: 8 }}>
+            <input type="radio" name="import-mode" checked={mode === "replace"}
+              onChange={() => setMode("replace")} disabled={importing} />
+            <span>
+              <strong>Ersetzen</strong> — die bestehende Speisekarte zuerst vollständig löschen.
+            </span>
+          </label>
+        </div>
+
+        {mode === "replace" && (
+          <p className="form-error" style={{ marginTop: 0 }}>
+            Achtung: Alle bestehenden Kategorien und Artikel dieses Events werden gelöscht.
+          </p>
+        )}
+        {error && <p className="form-error">{error}</p>}
+
+        <div className="modal-footer">
+          <button type="button" className="btn-secondary" onClick={onClose} disabled={importing}>Abbrechen</button>
+          <button type="button" className="btn-primary modal-submit" onClick={() => onConfirm(mode)} disabled={importing}>
+            {importing ? "Wird importiert…" : "Importieren"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
 // MenuPage
 // ---------------------------------------------------------------------------
 
@@ -327,6 +396,14 @@ export function MenuPage() {
   const [itemDelete, setItemDelete] = useState<MenuItemDto | null>(null);
   const [itemDeleting, setItemDeleting] = useState(false);
   const [itemDeleteErr, setItemDeleteErr] = useState<string | null>(null);
+
+  // Import / export
+  const [ioBusy, setIoBusy] = useState(false);
+  const [ioMsg, setIoMsg] = useState<string | null>(null);
+  const [ioErr, setIoErr] = useState<string | null>(null);
+  const [pendingImport, setPendingImport] = useState<MenuExport | null>(null);
+  const [importing, setImporting] = useState(false);
+  const [importErr, setImportErr] = useState<string | null>(null);
 
   // ── Load ─────────────────────────────────────────────────────────────────
 
@@ -568,6 +645,77 @@ export function MenuPage() {
     }
   }
 
+  // ── Import / export ────────────────────────────────────────────────────────
+
+  async function handleExport() {
+    setIoBusy(true);
+    setIoErr(null);
+    setIoMsg(null);
+    try {
+      const data = await api.menu.exportMenu();
+      const saved = await saveTextFile(
+        "speisekarte.json",
+        JSON.stringify(data, null, 2),
+        "json",
+      );
+      if (saved) {
+        const items = data.categories.reduce((s, c) => s + c.items.length, 0);
+        setIoMsg(`Exportiert: ${data.categories.length} Kategorien, ${items} Artikel.`);
+      }
+    } catch (err) {
+      setIoErr(err instanceof Error ? err.message : "Export fehlgeschlagen.");
+    } finally {
+      setIoBusy(false);
+    }
+  }
+
+  async function handleImportPick() {
+    setIoBusy(true);
+    setIoErr(null);
+    setIoMsg(null);
+    try {
+      const text = await openTextFile("json");
+      if (text == null) return; // cancelled
+      let raw: unknown;
+      try {
+        raw = JSON.parse(text);
+      } catch {
+        setIoErr("Die Datei ist kein gültiges JSON.");
+        return;
+      }
+      const parsed = MenuExportSchema.safeParse(raw);
+      if (!parsed.success) {
+        setIoErr("Die Datei ist keine gültige Speisekarten-Export-Datei.");
+        return;
+      }
+      setImportErr(null);
+      setPendingImport(parsed.data);
+    } catch (err) {
+      setIoErr(err instanceof Error ? err.message : "Datei konnte nicht gelesen werden.");
+    } finally {
+      setIoBusy(false);
+    }
+  }
+
+  async function handleImportConfirm(mode: "merge" | "replace") {
+    if (!pendingImport) return;
+    setImporting(true);
+    setImportErr(null);
+    try {
+      const res = await api.menu.importMenu({ menu: pendingImport, mode });
+      setPendingImport(null);
+      setIoMsg(
+        `Import abgeschlossen: ${res.categoriesCreated + res.categoriesUpdated} Kategorien, ` +
+          `${res.itemsCreated + res.itemsUpdated} Artikel.`,
+      );
+      await load();
+    } catch (err) {
+      setImportErr(err instanceof Error ? err.message : "Import fehlgeschlagen.");
+    } finally {
+      setImporting(false);
+    }
+  }
+
   // ── Loading / Error ───────────────────────────────────────────────────────
 
   if (state.status === "loading") {
@@ -599,12 +747,42 @@ export function MenuPage() {
 
   return (
     <>
-      <div className="page-header" style={{ marginBottom: 16 }}>
+      <div className="page-header" style={{ marginBottom: ioMsg || ioErr ? 8 : 16 }}>
         <h1 className="page-title">Speisekarte</h1>
-        {reordering && (
-          <span className="muted" style={{ fontSize: 12 }}>Reihenfolge wird gespeichert…</span>
-        )}
+        <div style={{ marginLeft: "auto", display: "flex", alignItems: "center", gap: 10 }}>
+          {reordering && (
+            <span className="muted" style={{ fontSize: 12 }}>Reihenfolge wird gespeichert…</span>
+          )}
+          <button
+            className="btn-secondary"
+            style={{ width: "auto", padding: "7px 14px", fontSize: 13 }}
+            onClick={handleExport}
+            disabled={ioBusy}
+            title="Speisekarte als Datei exportieren"
+          >
+            ⭳ Exportieren
+          </button>
+          <button
+            className="btn-secondary"
+            style={{ width: "auto", padding: "7px 14px", fontSize: 13 }}
+            onClick={handleImportPick}
+            disabled={ioBusy}
+            title="Speisekarte aus einer Datei importieren"
+          >
+            ⭱ Importieren
+          </button>
+        </div>
       </div>
+
+      {(ioMsg || ioErr) && (
+        <p
+          className={ioErr ? "form-error" : "muted"}
+          style={{ marginTop: 0, marginBottom: 16, fontSize: 13 }}
+          role={ioErr ? "alert" : undefined}
+        >
+          {ioErr ?? ioMsg}
+        </p>
+      )}
 
       {/* ── Two-panel layout ─────────────────────────────────────────── */}
       <div className="menu-layout">
@@ -904,6 +1082,16 @@ export function MenuPage() {
           onConfirm={handleItemDelete}
           deleting={itemDeleting}
           error={itemDeleteErr}
+        />
+      )}
+
+      {pendingImport != null && (
+        <ImportModal
+          menu={pendingImport}
+          onClose={() => setPendingImport(null)}
+          onConfirm={handleImportConfirm}
+          importing={importing}
+          error={importErr}
         />
       )}
     </>

--- a/apps/api/src/domain/menu-store.ts
+++ b/apps/api/src/domain/menu-store.ts
@@ -3,6 +3,8 @@ import type {
   MenuCategoryCreateRequest,
   MenuCategoryDto,
   MenuCategoryUpdateRequest,
+  MenuExport,
+  MenuImportResponse,
   MenuItemCreateRequest,
   MenuItemDto,
   MenuItemUpdateRequest,
@@ -426,6 +428,164 @@ export class MenuStore {
       }
 
       db.prepare("DELETE FROM MenuItems WHERE id = ?").run(menuItemId);
+    } finally {
+      db.close();
+    }
+  }
+
+  // ── Import / export ────────────────────────────────────────────────────────
+
+  // Snapshots the whole menu as a portable, id-free structure (categories with
+  // their nested items, in display order). Printer/display routing is dropped
+  // on purpose — those ids are event-specific and meaningless elsewhere.
+  exportMenu(): MenuExport {
+    const db = this.openActiveEventDb();
+    try {
+      const cats = db
+        .prepare(
+          `
+          SELECT id, name, description, isLocked, weight
+          FROM MenuCategories
+          ORDER BY weight ASC, name COLLATE NOCASE ASC
+          `
+        )
+        .all() as Array<{
+        id: number;
+        name: string;
+        description: string;
+        isLocked: number;
+        weight: number;
+      }>;
+
+      const itemStmt = db.prepare(
+        `
+        SELECT name, description, price, weight, isLocked
+        FROM MenuItems
+        WHERE menuCategory_id = ?
+        ORDER BY weight ASC, name COLLATE NOCASE ASC
+        `
+      );
+
+      const categories = cats.map((c) => {
+        const items = itemStmt.all(c.id) as Array<{
+          name: string;
+          description: string;
+          price: number;
+          weight: number;
+          isLocked: number;
+        }>;
+        return {
+          name: c.name,
+          description: c.description,
+          weight: c.weight,
+          isLocked: c.isLocked === 1,
+          items: items.map((it) => ({
+            name: it.name,
+            description: it.description,
+            price: it.price,
+            weight: it.weight,
+            isLocked: it.isLocked === 1,
+          })),
+        };
+      });
+
+      return {
+        formatVersion: 1,
+        exportedAt: new Date().toISOString(),
+        categories,
+      };
+    } finally {
+      db.close();
+    }
+  }
+
+  // Imports a menu snapshot into the active event. "replace" wipes the existing
+  // menu first; "merge" upserts categories and items by (case-insensitive) name
+  // so re-importing the same file is idempotent rather than duplicating rows.
+  // The whole thing runs in one transaction — a mid-import failure rolls back.
+  importMenu(input: { menu: MenuExport; mode: "merge" | "replace" }): MenuImportResponse {
+    const db = this.openActiveEventDb();
+    try {
+      let categoriesCreated = 0;
+      let categoriesUpdated = 0;
+      let itemsCreated = 0;
+      let itemsUpdated = 0;
+
+      const findCat = db.prepare(
+        "SELECT id FROM MenuCategories WHERE name = ? COLLATE NOCASE"
+      );
+      const insCat = db.prepare(
+        "INSERT INTO MenuCategories (name, description, isLocked, weight) VALUES (?, ?, ?, ?)"
+      );
+      const updCat = db.prepare(
+        "UPDATE MenuCategories SET description = ?, isLocked = ?, weight = ? WHERE id = ?"
+      );
+      const findItem = db.prepare(
+        "SELECT id FROM MenuItems WHERE menuCategory_id = ? AND name = ? COLLATE NOCASE"
+      );
+      const insItem = db.prepare(
+        "INSERT INTO MenuItems (name, description, weight, price, isLocked, menuCategory_id) VALUES (?, ?, ?, ?, ?, ?)"
+      );
+      const updItem = db.prepare(
+        "UPDATE MenuItems SET description = ?, weight = ?, price = ?, isLocked = ? WHERE id = ?"
+      );
+
+      const run = db.transaction(() => {
+        if (input.mode === "replace") {
+          db.prepare("DELETE FROM MenuItems").run();
+          db.prepare("DELETE FROM MenuCategories").run();
+        }
+
+        for (const cat of input.menu.categories) {
+          let categoryId: number;
+          const existingCat = findCat.get(cat.name) as { id: number } | undefined;
+          if (existingCat) {
+            categoryId = existingCat.id;
+            updCat.run(cat.description, cat.isLocked ? 1 : 0, cat.weight, categoryId);
+            categoriesUpdated += 1;
+          } else {
+            const res = insCat.run(cat.name, cat.description, cat.isLocked ? 1 : 0, cat.weight);
+            categoryId = Number(res.lastInsertRowid);
+            categoriesCreated += 1;
+          }
+
+          for (const item of cat.items) {
+            const existingItem = findItem.get(categoryId, item.name) as
+              | { id: number }
+              | undefined;
+            if (existingItem) {
+              updItem.run(
+                item.description,
+                item.weight,
+                item.price,
+                item.isLocked ? 1 : 0,
+                existingItem.id
+              );
+              itemsUpdated += 1;
+            } else {
+              insItem.run(
+                item.name,
+                item.description,
+                item.weight,
+                item.price,
+                item.isLocked ? 1 : 0,
+                categoryId
+              );
+              itemsCreated += 1;
+            }
+          }
+        }
+      });
+
+      run();
+
+      return {
+        mode: input.mode,
+        categoriesCreated,
+        categoriesUpdated,
+        itemsCreated,
+        itemsUpdated,
+      };
     } finally {
       db.close();
     }

--- a/apps/api/src/routes/menu.test.ts
+++ b/apps/api/src/routes/menu.test.ts
@@ -268,3 +268,126 @@ test("admin CRUD for menu categories and items works", { concurrency: false }, a
 
 });
 
+test("admin can export a menu and import it into another event", { concurrency: false }, async () => {
+  const adminPassword = "secret123";
+
+  // ── Source event with a seeded menu ──────────────────────────────────────
+  const source = createTestEvent({
+    eventName: createEventPrefix("menu-export"),
+    eventPasscode: "pass-export",
+    adminUsername: "chef",
+    adminPassword,
+  });
+  seedMenu(source.dbFilePath, {
+    categories: [
+      { name: "Getraenke", weight: 10 },
+      { name: "Speisen", weight: 20, isLocked: true, description: "Warme Kueche" },
+    ],
+    // menuCategoryId here is the 1-based insertion order returned by seedMenu.
+    items: [
+      { name: "Cola", weight: 10, price: 3.5, menuCategoryId: 1 },
+      { name: "Bier", weight: 20, price: 4.2, menuCategoryId: 1 },
+      { name: "Schnitzel", weight: 10, price: 14.9, menuCategoryId: 2, isLocked: true },
+    ],
+  });
+  eventStore.activateEvent(source.id);
+
+  const app = await createAppFixture(buildApp);
+  const auth = createAuthFixture(app);
+  const sourceToken = await auth.loginAdmin({
+    eventId: source.id,
+    username: "chef",
+    password: adminPassword,
+  });
+
+  const exportRes = await app.inject({
+    method: "GET",
+    url: "/menu/export",
+    headers: { authorization: `Bearer ${sourceToken}` },
+  });
+  assert.equal(exportRes.statusCode, 200);
+  const exported = exportRes.json() as {
+    formatVersion: number;
+    categories: Array<{ name: string; items: Array<{ name: string; price: number }> }>;
+  };
+  assert.equal(exported.formatVersion, 1);
+  assert.deepEqual(
+    exported.categories.map((c) => c.name),
+    ["Getraenke", "Speisen"],
+  );
+  assert.deepEqual(
+    exported.categories[0].items.map((i) => i.name),
+    ["Cola", "Bier"],
+  );
+
+  // ── Target event (empty menu) ────────────────────────────────────────────
+  const target = createTestEvent({
+    eventName: createEventPrefix("menu-import"),
+    eventPasscode: "pass-import",
+    adminUsername: "chef",
+    adminPassword,
+  });
+  eventStore.activateEvent(target.id);
+  const targetToken = await auth.loginAdmin({
+    eventId: target.id,
+    username: "chef",
+    password: adminPassword,
+  });
+
+  const importRes = await app.inject({
+    method: "POST",
+    url: "/menu/import",
+    headers: { authorization: `Bearer ${targetToken}` },
+    payload: { menu: exported },
+  });
+  assert.equal(importRes.statusCode, 200);
+  assert.deepEqual(importRes.json(), {
+    mode: "merge",
+    categoriesCreated: 2,
+    categoriesUpdated: 0,
+    itemsCreated: 3,
+    itemsUpdated: 0,
+  });
+
+  // Menu now exists in the target event.
+  const targetCats = await app.inject({
+    method: "GET",
+    url: "/menu/categories",
+    headers: { authorization: `Bearer ${targetToken}` },
+  });
+  assert.deepEqual(
+    (targetCats.json() as { categories: Array<{ name: string }> }).categories.map((c) => c.name),
+    ["Getraenke", "Speisen"],
+  );
+  const targetItems = await app.inject({
+    method: "GET",
+    url: "/menu/items",
+    headers: { authorization: `Bearer ${targetToken}` },
+  });
+  const items = (targetItems.json() as { items: Array<{ name: string; isLocked: boolean }> }).items;
+  assert.equal(items.length, 3);
+  assert.equal(items.find((i) => i.name === "Schnitzel")?.isLocked, true);
+
+  // Re-importing the same file is idempotent (upsert by name, no duplicates).
+  const reimport = await app.inject({
+    method: "POST",
+    url: "/menu/import",
+    headers: { authorization: `Bearer ${targetToken}` },
+    payload: { menu: exported },
+  });
+  assert.equal(reimport.statusCode, 200);
+  assert.deepEqual(reimport.json(), {
+    mode: "merge",
+    categoriesCreated: 0,
+    categoriesUpdated: 2,
+    itemsCreated: 0,
+    itemsUpdated: 3,
+  });
+  const afterReimport = await app.inject({
+    method: "GET",
+    url: "/menu/items",
+    headers: { authorization: `Bearer ${targetToken}` },
+  });
+  assert.equal((afterReimport.json() as { items: unknown[] }).items.length, 3);
+});
+

--- a/apps/api/src/routes/menu.ts
+++ b/apps/api/src/routes/menu.ts
@@ -22,6 +22,10 @@
   MenuItemsQuery,
   MenuItemsQuerySchema,
   MenuItemsResponseSchema,
+  MenuExportSchema,
+  MenuImportRequest,
+  MenuImportRequestSchema,
+  MenuImportResponseSchema,
 } from "@serva/shared-types";
 import type { FastifyInstance } from "fastify";
 import { z } from "zod";
@@ -270,6 +274,59 @@ export function registerMenuRoutes(app: FastifyInstance) {
       menuStore.deleteItem(request.params.menuItemId);
       return reply.status(204).send();
     }
+  );
+
+  app.get(
+    "/menu/export",
+    {
+      config: {
+        requiresRole: "admin",
+        requiresActiveEvent: true,
+      },
+      schema: {
+        tags: ["menu"],
+        operationId: "menuExport",
+        summary: "Speisekarte exportieren",
+        description:
+          "Exportiert die komplette Speisekarte (Kategorien inkl. Artikel) des aktiven Events als portable JSON-Struktur. Drucker-/Display-Zuordnungen werden bewusst nicht mit exportiert.",
+        security: [{ bearerAuth: [] }],
+        response: {
+          200: MenuExportSchema,
+          401: ApiErrorEnvelopeSchema,
+          403: ApiErrorEnvelopeSchema,
+          409: ApiErrorEnvelopeSchema,
+        },
+      },
+    },
+    async () => menuStore.exportMenu()
+  );
+
+  app.post<{ Body: MenuImportRequest }>(
+    "/menu/import",
+    {
+      config: {
+        requiresRole: "admin",
+        requiresActiveEvent: true,
+      },
+      schema: {
+        tags: ["menu"],
+        operationId: "menuImport",
+        summary: "Speisekarte importieren",
+        description:
+          "Importiert eine exportierte Speisekarte in das aktive Event. mode='merge' (Standard) fuegt Kategorien/Artikel per Name zusammen (idempotent); mode='replace' ersetzt die bestehende Speisekarte vollstaendig.",
+        security: [{ bearerAuth: [] }],
+        body: MenuImportRequestSchema,
+        response: {
+          200: MenuImportResponseSchema,
+          400: ApiErrorEnvelopeSchema,
+          401: ApiErrorEnvelopeSchema,
+          403: ApiErrorEnvelopeSchema,
+          409: ApiErrorEnvelopeSchema,
+        },
+      },
+    },
+    async (request) =>
+      menuStore.importMenu({ menu: request.body.menu, mode: request.body.mode })
   );
 }
 

--- a/packages/api-client/src/routes/menu.ts
+++ b/packages/api-client/src/routes/menu.ts
@@ -9,12 +9,18 @@ import {
   MenuItemsResponseSchema,
   MenuItemUpdateRequestSchema,
   MenuItemUpdateResponseSchema,
+  MenuExportSchema,
+  MenuImportRequestSchema,
+  MenuImportResponseSchema,
   type MenuCategoriesQuery,
   type MenuCategoriesResponse,
   type MenuCategoryCreateRequest,
   type MenuCategoryCreateResponse,
   type MenuCategoryUpdateRequest,
   type MenuCategoryUpdateResponse,
+  type MenuExport,
+  type MenuImportRequest,
+  type MenuImportResponse,
   type MenuItemCreateRequest,
   type MenuItemCreateResponse,
   type MenuItemsQuery,
@@ -33,6 +39,8 @@ export interface MenuClient {
   createItem(body: MenuItemCreateRequest): Promise<MenuItemCreateResponse>;
   updateItem(menuItemId: number, body: MenuItemUpdateRequest): Promise<MenuItemUpdateResponse>;
   deleteItem(menuItemId: number): Promise<void>;
+  exportMenu(): Promise<MenuExport>;
+  importMenu(body: MenuImportRequest): Promise<MenuImportResponse>;
 }
 
 export function createMenuClient(http: HttpTransport): MenuClient {
@@ -83,5 +91,14 @@ export function createMenuClient(http: HttpTransport): MenuClient {
 
     deleteItem: (menuItemId) =>
       http.deleteVoid(`/menu/items/${menuItemId}`),
+
+    exportMenu: () => http.get(MenuExportSchema, "/menu/export"),
+
+    importMenu: (body) =>
+      http.post(
+        MenuImportResponseSchema,
+        "/menu/import",
+        MenuImportRequestSchema.parse(body),
+      ),
   };
 }

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -514,6 +514,64 @@ export type MenuItemCreateResponse = MenuItemDto;
 export const MenuItemUpdateResponseSchema = MenuItemDtoSchema;
 export type MenuItemUpdateResponse = MenuItemDto;
 
+// ─── Menu import / export ────────────────────────────────────────────────────
+// A portable snapshot of the whole menu — categories with their nested items —
+// carrying only content, not event-specific ids or printer/display routing, so
+// it can be moved to a different event. Categories and items are matched by
+// name on import.
+
+export const MenuExportItemSchema = z
+  .object({
+    name: nonEmptyString,
+    description: z.string(),
+    price: z.number().nonnegative(),
+    weight: z.number().int(),
+    isLocked: z.boolean(),
+  })
+  .strict();
+export type MenuExportItem = z.infer<typeof MenuExportItemSchema>;
+
+export const MenuExportCategorySchema = z
+  .object({
+    name: nonEmptyString,
+    description: z.string(),
+    weight: z.number().int(),
+    isLocked: z.boolean(),
+    items: z.array(MenuExportItemSchema),
+  })
+  .strict();
+export type MenuExportCategory = z.infer<typeof MenuExportCategorySchema>;
+
+export const MenuExportSchema = z
+  .object({
+    formatVersion: z.literal(1),
+    exportedAt: z.string(),
+    categories: z.array(MenuExportCategorySchema),
+  })
+  .strict();
+export type MenuExport = z.infer<typeof MenuExportSchema>;
+
+export const MenuImportRequestSchema = z
+  .object({
+    // "merge" upserts categories/items by name (idempotent); "replace" wipes the
+    // target event's menu first for a clean copy.
+    mode: z.enum(["merge", "replace"]).default("merge"),
+    menu: MenuExportSchema,
+  })
+  .strict();
+export type MenuImportRequest = z.infer<typeof MenuImportRequestSchema>;
+
+export const MenuImportResponseSchema = z
+  .object({
+    mode: z.enum(["merge", "replace"]),
+    categoriesCreated: z.number().int().nonnegative(),
+    categoriesUpdated: z.number().int().nonnegative(),
+    itemsCreated: z.number().int().nonnegative(),
+    itemsUpdated: z.number().int().nonnegative(),
+  })
+  .strict();
+export type MenuImportResponse = z.infer<typeof MenuImportResponseSchema>;
+
 export const StockItemDtoSchema = z
   .object({
     id: positiveInt,


### PR DESCRIPTION
Closes #135

## What
Lets an admin export the whole menu to a file and import it — including into another event.

## API
- **`GET /menu/export`** — returns categories with their nested items as a portable, id-free snapshot (`formatVersion`, `exportedAt`, `categories[]`). Printer/display routing is intentionally omitted since those ids are event-specific.
- **`POST /menu/import`** — body `{ menu, mode }`. `mode: "merge"` (default) upserts categories/items by case-insensitive name (idempotent — re-importing doesn't duplicate); `mode: "replace"` wipes the target event's menu first. Runs in a single transaction and returns created/updated counts.
- `shared-types`: `MenuExport` / `MenuImportRequest` / `MenuImportResponse` schemas.
- `api-client`: `menu.exportMenu()` and `menu.importMenu()`.

## Admin desktop
- **Export** / **Import** buttons on the Speisekarte page.
  - Export saves a `.json` file (Tauri save dialog; browser download fallback in `vite dev`).
  - Import picks a file, validates it against the export schema, then shows a confirm modal with a **merge / replace** choice and the category/item counts, and reloads on success.
- Tauri `capabilities` gain `dialog:allow-open` + `fs:allow-read-file`.

## Verification
- New API round-trip test (`menu.test.ts`): seed a menu in event A → export → import into empty event B → assert categories/items present, locked flags preserved, and re-import is idempotent (upsert, no dupes). Passes.
- `tsc` + `vite build` clean for API, api-client, and admin-desktop; full API suite green apart from the 2 pre-existing unrelated "reject unauthorized" failures.

**Note:** API source changed, so the desktop's bundled `server.mjs` should be rebuilt for the packaged app — `pnpm tauri:build` does this via `build:runtime`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)