### PR TITLE
feat(api/admin-desktop): export statistics data file (#136)

### DIFF
--- a/apps/admin-desktop/src/lib/orders-csv.ts
+++ b/apps/admin-desktop/src/lib/orders-csv.ts
@@ -1,0 +1,39 @@
+import type { OrdersExportResponse, OrdersExportRow } from "@serva/shared-types";
+
+// Builds an RFC-4180 CSV from the flat orders export: comma-delimited, CRLF
+// line endings, fields quoted only when needed. Numbers keep the dot decimal
+// separator and timestamps stay ISO-8601 so the file imports cleanly into
+// analysis tools (pandas, R, Excel import wizard). A UTF-8 BOM is prepended so
+// Excel detects the encoding and umlauts survive a plain double-click open.
+
+const COLUMNS: Array<{ header: string; value: (r: OrdersExportRow) => string | number }> = [
+  { header: "orderId", value: (r) => r.orderId },
+  { header: "timestamp", value: (r) => r.timestamp },
+  { header: "tableId", value: (r) => r.tableId },
+  { header: "tableName", value: (r) => r.tableName },
+  { header: "userId", value: (r) => r.userId },
+  { header: "waiterUsername", value: (r) => r.waiterUsername },
+  { header: "menuItemId", value: (r) => r.menuItemId },
+  { header: "menuItemName", value: (r) => r.menuItemName },
+  { header: "categoryName", value: (r) => r.categoryName },
+  { header: "quantity", value: (r) => r.quantity },
+  { header: "unitPrice", value: (r) => r.unitPrice },
+  { header: "lineTotal", value: (r) => r.lineTotal },
+  { header: "specialRequests", value: (r) => r.specialRequests },
+];
+
+function escapeField(value: string | number): string {
+  const text = String(value);
+  if (/[",\r\n]/.test(text)) {
+    return `"${text.replace(/"/g, '""')}"`;
+  }
+  return text;
+}
+
+export function buildOrdersCsv(data: OrdersExportResponse): string {
+  const lines = [COLUMNS.map((c) => c.header).join(",")];
+  for (const row of data.rows) {
+    lines.push(COLUMNS.map((c) => escapeField(c.value(row))).join(","));
+  }
+  return "\uFEFF" + lines.join("\r\n") + "\r\n";
+}

--- a/apps/admin-desktop/src/pages/StatisticsPage.tsx
+++ b/apps/admin-desktop/src/pages/StatisticsPage.tsx
@@ -1,6 +1,8 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { MenuItemDto, OrderDto, UserDto } from "@serva/shared-types";
 import { useApiClient } from "../contexts/ApiClientContext";
+import { saveTextFile } from "../lib/menu-file";
+import { buildOrdersCsv } from "../lib/orders-csv";
 
 // ---------------------------------------------------------------------------
 // Constants & helpers
@@ -381,20 +383,71 @@ export function StatisticsPage() {
     [orders, prices, bucketChoice],
   );
 
+  // CSV export (issue #136): fetch the flat order-line dump from the API,
+  // serialize it and save via the shared file helper (Tauri dialog or
+  // browser download in `vite dev`).
+  const [exporting, setExporting] = useState(false);
+  const [exportMsg, setExportMsg] = useState<string | null>(null);
+  const [exportErr, setExportErr] = useState<string | null>(null);
+
+  async function handleExportCsv() {
+    setExporting(true);
+    setExportMsg(null);
+    setExportErr(null);
+    try {
+      const data = await api.orders.exportData();
+      const date = new Date().toISOString().slice(0, 10);
+      const saved = await saveTextFile(
+        `bestellungen-${date}.csv`,
+        buildOrdersCsv(data),
+        "csv",
+      );
+      if (saved) {
+        setExportMsg(`Exportiert: ${int.format(data.rows.length)} Positionen.`);
+      }
+    } catch (err) {
+      setExportErr(
+        err instanceof Error ? err.message : "Export fehlgeschlagen.",
+      );
+    } finally {
+      setExporting(false);
+    }
+  }
+
   const header = (
     <div className="page-header">
       <h1 className="page-title">Statistik</h1>
-      <span className="stats-live">
-        <span className="stats-live__dot" aria-hidden="true" />
-        Live · alle 5&nbsp;Sekunden
-        {lastUpdated && (
-          <span className="muted">
-            {" "}
-            (zuletzt {clockFmt.format(lastUpdated)})
-          </span>
-        )}
-      </span>
+      <div style={{ marginLeft: "auto", display: "flex", alignItems: "center", gap: 14 }}>
+        <span className="stats-live">
+          <span className="stats-live__dot" aria-hidden="true" />
+          Live · alle 5&nbsp;Sekunden
+          {lastUpdated && (
+            <span className="muted">
+              {" "}
+              (zuletzt {clockFmt.format(lastUpdated)})
+            </span>
+          )}
+        </span>
+        <button
+          className="btn-secondary"
+          style={{ width: "auto", padding: "7px 14px", fontSize: 13 }}
+          onClick={handleExportCsv}
+          disabled={exporting || orders.length === 0}
+          title="Alle Bestelldaten als CSV-Datei exportieren"
+        >
+          {exporting ? "Wird exportiert…" : "⭳ CSV exportieren"}
+        </button>
+      </div>
     </div>
+  );
+
+  const exportStatus = (exportMsg || exportErr) && (
+    <p
+      className={exportErr ? "form-error" : "muted"}
+      style={{ margin: "-12px 0 16px", fontSize: 13 }}
+    >
+      {exportErr ?? exportMsg}
+    </p>
   );
 
   if (state.status === "loading" && orders.length === 0) {
@@ -427,6 +480,7 @@ export function StatisticsPage() {
   return (
     <div>
       {header}
+      {exportStatus}
 
       <div className="stats-kpi-grid">
         <StatCard label="Umsatz" value={eur.format(stats.revenue)} accent />

--- a/apps/api/src/domain/order-store.ts
+++ b/apps/api/src/domain/order-store.ts
@@ -2,6 +2,7 @@
 import type {
   OrderDto,
   OrderItemDto,
+  OrdersExportResponse,
   OrdersQuery,
   OrderSubmitRequest,
 } from "@serva/shared-types";
@@ -424,6 +425,66 @@ export class OrderStore {
       return rows
         .map((row) => this.loadOrder(db, row.id))
         .filter((order): order is OrderDto => order !== null);
+    } finally {
+      db.close();
+    }
+  }
+
+  // Flat dump of every order line for offline analysis: one row per order
+  // item, denormalized with table/waiter/menu-item/category names. LEFT JOINs
+  // keep rows whose referenced table/user/menu item was deleted after the
+  // order was taken (names fall back to ""). unitPrice is the menu item's
+  // current price — historical prices are not stored.
+  exportOrders(): OrdersExportResponse {
+    const db = this.openActiveEventDb();
+    try {
+      const rows = db
+        .prepare(
+          `
+          SELECT
+            o.id as orderId,
+            o.timestamp,
+            o.table_id as tableId,
+            COALESCE(t.name, '') as tableName,
+            o.user_id as userId,
+            COALESCE(u.username, '') as waiterUsername,
+            oi.menuItem_id as menuItemId,
+            COALESCE(mi.name, '') as menuItemName,
+            COALESCE(mc.name, '') as categoryName,
+            oi.quantity,
+            COALESCE(mi.price, 0) as unitPrice,
+            oi.specialRequests
+          FROM Orders o
+          JOIN OrderItems oi ON oi.order_id = o.id
+          LEFT JOIN Tables t ON t.id = o.table_id
+          LEFT JOIN Users u ON u.id = o.user_id
+          LEFT JOIN MenuItems mi ON mi.id = oi.menuItem_id
+          LEFT JOIN MenuCategories mc ON mc.id = mi.menuCategory_id
+          ORDER BY o.timestamp ASC, o.id ASC, oi.rowid ASC
+          `
+        )
+        .all() as Array<{
+        orderId: number;
+        timestamp: string;
+        tableId: number;
+        tableName: string;
+        userId: number;
+        waiterUsername: string;
+        menuItemId: number;
+        menuItemName: string;
+        categoryName: string;
+        quantity: number;
+        unitPrice: number;
+        specialRequests: string;
+      }>;
+
+      return {
+        exportedAt: new Date().toISOString(),
+        rows: rows.map((row) => ({
+          ...row,
+          lineTotal: row.unitPrice * row.quantity,
+        })),
+      };
     } finally {
       db.close();
     }

--- a/apps/api/src/routes/orders.test.ts
+++ b/apps/api/src/routes/orders.test.ts
@@ -376,3 +376,96 @@ test("orders endpoint returns proper edge-case errors", { concurrency: false }, 
 
 });
 
+test("admin can export all order data as flat rows; waiters cannot", { concurrency: false }, async () => {
+  const eventPasscode = "orders-export-pass";
+  const adminPassword = "secret123";
+  const created = createActiveDbFixture({
+    eventName: createEventPrefix("orders-export"),
+    eventPasscode,
+    adminUsername: "chef",
+    adminPassword,
+  }).event;
+  const { tableId, menuItemId } = seedOrderBaseData(created.dbFilePath);
+
+  const app = await createAppFixture(buildApp);
+  const auth = createAuthFixture(app);
+  const waiterA = await auth.loginWaiter({ username: "waiter-export-a", eventPasscode });
+  const waiterB = await auth.loginWaiter({ username: "waiter-export-b", eventPasscode });
+  const adminToken = await auth.loginAdmin({
+    eventId: created.id,
+    username: "chef",
+    password: adminPassword,
+  });
+
+  const firstOrder = await app.inject({
+    method: "POST",
+    url: "/orders",
+    headers: { authorization: `Bearer ${waiterA.accessToken}` },
+    payload: {
+      tableId,
+      items: [{ menuItemId, quantity: 2, specialRequests: "No onions" }],
+    },
+  });
+  assert.equal(firstOrder.statusCode, 201);
+
+  const secondOrder = await app.inject({
+    method: "POST",
+    url: "/orders",
+    headers: { authorization: `Bearer ${waiterB.accessToken}` },
+    payload: {
+      tableId,
+      items: [{ menuItemId, quantity: 1 }],
+    },
+  });
+  assert.equal(secondOrder.statusCode, 201);
+
+  const forbidden = await app.inject({
+    method: "GET",
+    url: "/orders/export",
+    headers: { authorization: `Bearer ${waiterA.accessToken}` },
+  });
+  assert.equal(forbidden.statusCode, 403);
+
+  const exportRes = await app.inject({
+    method: "GET",
+    url: "/orders/export",
+    headers: { authorization: `Bearer ${adminToken}` },
+  });
+  assert.equal(exportRes.statusCode, 200);
+
+  const body = exportRes.json() as {
+    exportedAt: string;
+    rows: Array<{
+      orderId: number;
+      timestamp: string;
+      tableName: string;
+      waiterUsername: string;
+      menuItemName: string;
+      categoryName: string;
+      quantity: number;
+      unitPrice: number;
+      lineTotal: number;
+      specialRequests: string;
+    }>;
+  };
+
+  assert.equal(body.rows.length, 2);
+
+  const first = body.rows[0];
+  assert.equal(first.orderId, (firstOrder.json() as { id: number }).id);
+  assert.equal(first.tableName, "A1");
+  assert.equal(first.waiterUsername, "waiter-export-a");
+  assert.equal(first.menuItemName, "Burger");
+  assert.equal(first.categoryName, "Food");
+  assert.equal(first.quantity, 2);
+  assert.equal(first.unitPrice, 7.5);
+  assert.equal(first.lineTotal, 15);
+  assert.equal(first.specialRequests, "No onions");
+
+  const second = body.rows[1];
+  assert.equal(second.waiterUsername, "waiter-export-b");
+  assert.equal(second.quantity, 1);
+  assert.equal(second.lineTotal, 7.5);
+  assert.equal(second.specialRequests, "");
+});
+

--- a/apps/api/src/routes/orders.ts
+++ b/apps/api/src/routes/orders.ts
@@ -4,6 +4,7 @@
   OrderParams,
   OrderParamsSchema,
   OrderPrintResponseSchema,
+  OrdersExportResponseSchema,
   OrdersQuery,
   OrdersQuerySchema,
   OrdersResponseSchema,
@@ -67,6 +68,31 @@ export function registerOrderRoutes(app: FastifyInstance) {
         }),
       };
     }
+  );
+
+  app.get(
+    "/orders/export",
+    {
+      config: {
+        requiresRole: "admin",
+        requiresActiveEvent: true,
+      },
+      schema: {
+        tags: ["orders"],
+        operationId: "ordersExport",
+        summary: "Bestelldaten exportieren",
+        description:
+          "Liefert alle Bestellpositionen des aktiven Events als flache, denormalisierte Zeilen (inkl. Tisch-, Kellner-, Artikel- und Kategorienamen) fuer die Datenanalyse, z.B. als CSV-Export.",
+        security: [{ bearerAuth: [] }],
+        response: {
+          200: OrdersExportResponseSchema,
+          401: ApiErrorEnvelopeSchema,
+          403: ApiErrorEnvelopeSchema,
+          409: ApiErrorEnvelopeSchema,
+        },
+      },
+    },
+    async () => orderStore.exportOrders()
   );
 
   app.post<{ Body: OrderSubmitRequest }>(

--- a/packages/api-client/src/routes/orders.ts
+++ b/packages/api-client/src/routes/orders.ts
@@ -1,11 +1,13 @@
 import {
   OrderGetResponseSchema,
   OrderPrintResponseSchema,
+  OrdersExportResponseSchema,
   OrdersResponseSchema,
   OrderSubmitRequestSchema,
   OrderSubmitResponseSchema,
   type OrderGetResponse,
   type OrderPrintResponse,
+  type OrdersExportResponse,
   type OrdersQuery,
   type OrdersResponse,
   type OrderSubmitRequest,
@@ -23,6 +25,11 @@ export interface OrdersClient {
    * printer doesn't fail the call — inspect `results[].status` instead.
    */
   print(orderId: number): Promise<OrderPrintResponse>;
+  /**
+   * Flat, denormalized dump of every order line of the active event (one row
+   * per order item, names already joined) for offline analysis. Admin only.
+   */
+  exportData(): Promise<OrdersExportResponse>;
 }
 
 export function createOrdersClient(http: HttpTransport): OrdersClient {
@@ -47,5 +54,7 @@ export function createOrdersClient(http: HttpTransport): OrdersClient {
 
     print: (orderId) =>
       http.post(OrderPrintResponseSchema, `/orders/${orderId}/print`),
+
+    exportData: () => http.get(OrdersExportResponseSchema, "/orders/export"),
   };
 }

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -1058,6 +1058,40 @@ export type OrdersResponse = z.infer<typeof OrdersResponseSchema>;
 export const OrderGetResponseSchema = OrderDtoSchema;
 export type OrderGetResponse = OrderDto;
 
+// ─── Orders export ───────────────────────────────────────────────────────────
+// A flat, denormalized dump of every order line of the active event, meant for
+// offline analysis (CSV/spreadsheet). One row per order item, already joined
+// with table, waiter, menu item and category names. Name fields fall back to
+// "" when the referenced row was deleted after the order was taken; unitPrice
+// is the menu item's *current* price (historical prices are not stored).
+
+export const OrdersExportRowSchema = z
+  .object({
+    orderId: positiveInt,
+    timestamp: z.string(),
+    tableId: positiveInt,
+    tableName: z.string(),
+    userId: positiveInt,
+    waiterUsername: z.string(),
+    menuItemId: positiveInt,
+    menuItemName: z.string(),
+    categoryName: z.string(),
+    quantity: z.number().int().nonnegative(),
+    unitPrice: z.number().nonnegative(),
+    lineTotal: z.number().nonnegative(),
+    specialRequests: z.string(),
+  })
+  .strict();
+export type OrdersExportRow = z.infer<typeof OrdersExportRowSchema>;
+
+export const OrdersExportResponseSchema = z
+  .object({
+    exportedAt: z.string(),
+    rows: z.array(OrdersExportRowSchema),
+  })
+  .strict();
+export type OrdersExportResponse = z.infer<typeof OrdersExportResponseSchema>;
+
 // ─── Order printing ─────────────────────────────────────────────────────────
 // A waiter submits an order, then triggers a print run. The API groups the
 // order's items by their menu category's assigned printer and sends one bon


### PR DESCRIPTION
Closes #136

Lets the admin export all order data of the active event as a CSV file for further data analysis.

## API
- `GET /orders/export` (admin only, active event required) returns a flat, denormalized dump: one row per order item with `orderId`, `timestamp`, table id/name, waiter id/username, menu item id/name, category name, `quantity`, `unitPrice`, `lineTotal` and `specialRequests`.
- `LEFT JOIN`s keep order lines whose table/waiter/menu item was deleted after the order was taken (names fall back to `""`). `unitPrice` is the menu item's *current* price — historical prices are not stored (same limitation the statistics page already has).
- `shared-types`: `OrdersExportRowSchema` / `OrdersExportResponseSchema`; `api-client`: `orders.exportData()`.

## Admin desktop
- New **⭳ CSV exportieren** button in the statistics page header (disabled while exporting or when there are no orders yet), with a success/error status line below the header.
- CSV is RFC-4180: comma-delimited, CRLF, fields quoted only when needed, ISO-8601 timestamps, dot decimals — imports cleanly into pandas/R/Excel. A UTF-8 BOM is prepended so umlauts survive a plain double-click open in Excel.
- Saved via the shared Tauri-dialog/browser-download helper as `bestellungen-<yyyy-mm-dd>.csv`.

## Tests
- New API test: admin export returns correct joined rows (names, prices, line totals, special requests); waiters get 403.
- `apps/api` orders tests: 6/6 pass; full suite has 2 pre-existing failures (`menu`/`tables` "reject unauthorized" expect 401 but get 409) that also fail on `main` — unrelated to this change.
- `shared-types`, `api-client` (19/19 tests) and `admin-desktop` all build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)