### PR TITLE
fix(api): enforce auth on routes that only declare allowedRoles

### DIFF
--- a/apps/api/src/plugins/jwt-auth-guard.ts
+++ b/apps/api/src/plugins/jwt-auth-guard.ts
@@ -24,7 +24,13 @@ const AuthClaimsSchema = z.discriminatedUnion("role", [
 export function registerJwtAuthGuard(app: FastifyInstance) {
   app.addHook("preHandler", async (request) => {
     const routeConfig = request.routeOptions.config;
-    const requiresAuth = Boolean(routeConfig?.requiresAuth || routeConfig?.requiresRole);
+    // allowedRoles implies auth: routes declaring only allowedRoles (without
+    // requiresAuth) would otherwise skip token validation entirely and either
+    // leak through to the handler unauthenticated or surface as 409
+    // NO_ACTIVE_EVENT instead of 401.
+    const requiresAuth = Boolean(
+      routeConfig?.requiresAuth || routeConfig?.requiresRole || routeConfig?.allowedRoles
+    );
     if (!requiresAuth) {
       return;
     }


### PR DESCRIPTION
## Problem
Two tests were failing on `main` (`menu`/`tables` "reject unauthorized requests": expected 401, got 409). Root cause: the JWT auth guard only engaged when `requiresAuth` or `requiresRole` was set. Three routes are configured with **only** `allowedRoles` — `GET /tables`, `GET /menu/categories`, `GET /menu/items` — so the guard never ran on them:

- without an active event, unauthenticated requests fell through to the active-event guard → `409 NO_ACTIVE_EVENT` instead of `401` (the failing tests);
- **with an active event, unauthenticated requests reached the handler with no token validation at all** — menu and table lists were publicly readable while an event is running.

Every other `allowedRoles` route pairs it with `requiresAuth: true`, which masked this.

## Fix
The guard now treats `allowedRoles` as implying auth (`requiresAuth || requiresRole || allowedRoles`), so a missing/invalid token is rejected with 401 before the role and active-event checks.

## Tests
Full API suite: **53/53 pass** (was 51/53 on `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)