### PR TITLE
feat(api/admin-desktop): event backup & restore (export/import full event data)

### DIFF
--- a/apps/admin-desktop/src/pages/EventsPage.tsx
+++ b/apps/admin-desktop/src/pages/EventsPage.tsx
@@ -2,8 +2,18 @@ import { useEffect, useState, type FormEvent } from "react";
 import { useNavigate } from "react-router-dom";
 import { useAuth } from "@bstoema/auth-context";
 import { useApiClient } from "../contexts/ApiClientContext";
-import type { EventDto, AdminEventCreateRequest } from "@bstoema/shared-types";
+import type { EventDto, AdminEventCreateRequest, EventBackupFile } from "@bstoema/shared-types";
 import { WindowControls } from "../components/WindowControls";
+import { openTextFile, saveTextFile } from "../lib/menu-file";
+
+/** Turns an event name into a safe filename fragment. */
+function toFileSlug(name: string) {
+  return name.replace(/[^a-zA-Z0-9äöüÄÖÜß _-]+/g, "").trim().replace(/\s+/g, "-") || "event";
+}
+
+function backupFileName(slug: string) {
+  return `bstoema-backup-${slug}-${new Date().toISOString().slice(0, 10)}.json`;
+}
 
 type EventStatus = "active" | "inactive" | "closed";
 
@@ -32,6 +42,8 @@ export function EventsPage() {
   const [createError, setCreateError] = useState<string | null>(null);
   const [form, setForm] = useState<AdminEventCreateRequest>(EMPTY_FORM);
   const [busy, setBusy] = useState<Record<number, boolean>>({});
+  const [backupBusy, setBackupBusy] = useState(false);
+  const [backupNotice, setBackupNotice] = useState<string | null>(null);
 
   function setBusyFor(id: number, val: boolean) {
     setBusy((prev) => ({ ...prev, [id]: val }));
@@ -84,6 +96,67 @@ export function EventsPage() {
     try { await api.adminEvents.close(id); await reload(); } finally { setBusyFor(id, false); }
   }
 
+  async function handleExport(ev: EventDto) {
+    setBusyFor(ev.id, true);
+    setBackupNotice(null);
+    try {
+      const backup = await api.adminEvents.exportEvent(ev.id);
+      const saved = await saveTextFile(
+        backupFileName(toFileSlug(ev.eventName)),
+        JSON.stringify(backup, null, 2),
+        "json",
+      );
+      if (saved) setBackupNotice(`"${ev.eventName}" wurde exportiert.`);
+    } catch {
+      setBackupNotice("Export fehlgeschlagen.");
+    } finally {
+      setBusyFor(ev.id, false);
+    }
+  }
+
+  async function handleExportAll() {
+    setBackupBusy(true);
+    setBackupNotice(null);
+    try {
+      const backup = await api.adminEvents.exportAll();
+      const saved = await saveTextFile(
+        backupFileName("alle-veranstaltungen"),
+        JSON.stringify(backup, null, 2),
+        "json",
+      );
+      if (saved) setBackupNotice(`${backup.events.length} Veranstaltung(en) exportiert.`);
+    } catch {
+      setBackupNotice("Export fehlgeschlagen.");
+    } finally {
+      setBackupBusy(false);
+    }
+  }
+
+  async function handleImport() {
+    setBackupBusy(true);
+    setBackupNotice(null);
+    try {
+      const text = await openTextFile("json");
+      if (text === null) return;
+
+      let backup: EventBackupFile;
+      try {
+        backup = JSON.parse(text) as EventBackupFile;
+      } catch {
+        setBackupNotice("Die Datei ist kein gueltiges Veranstaltungs-Backup.");
+        return;
+      }
+
+      const result = await api.adminEvents.importBackup(backup);
+      setBackupNotice(`${result.events.length} Veranstaltung(en) importiert.`);
+      await reload();
+    } catch {
+      setBackupNotice("Import fehlgeschlagen. Ist die Datei ein gueltiges Veranstaltungs-Backup?");
+    } finally {
+      setBackupBusy(false);
+    }
+  }
+
   const active   = events.filter((e) => getStatus(e) === "active");
   const inactive = events.filter((e) => getStatus(e) === "inactive");
   const closed   = events.filter((e) => getStatus(e) === "closed");
@@ -107,9 +180,19 @@ export function EventsPage() {
               <button className="btn-secondary" onClick={() => setShowCreate((v) => !v)}>
                 {showCreate ? "Abbrechen" : "+ Neue Veranstaltung"}
               </button>
+              <button className="btn-ghost" disabled={backupBusy} onClick={handleImport}>
+                Importieren
+              </button>
+              <button className="btn-ghost" disabled={backupBusy || events.length === 0} onClick={handleExportAll}>
+                Alle exportieren
+              </button>
               <button className="btn-ghost" onClick={logout}>Abmelden</button>
             </div>
           </div>
+
+          {backupNotice && (
+            <p className="muted" style={{ marginBottom: 16 }}>{backupNotice}</p>
+          )}
 
           {/* Create form */}
           {showCreate && (
@@ -160,7 +243,8 @@ export function EventsPage() {
                 <EventRow key={ev.id} ev={ev} busy={!!busy[ev.id]}
                   onAdminLogin={() => navigate(`/events/${ev.id}/admin-login`)}
                   onDeactivate={() => handleDeactivate(ev.id)}
-                  onClose={() => handleClose(ev.id)} />
+                  onClose={() => handleClose(ev.id)}
+                  onExport={() => handleExport(ev)} />
               ))}
 
               {inactive.length > 0 && (
@@ -169,7 +253,8 @@ export function EventsPage() {
                   {inactive.map((ev) => (
                     <EventRow key={ev.id} ev={ev} busy={!!busy[ev.id]}
                       onActivate={() => handleActivate(ev.id)}
-                      onClose={() => handleClose(ev.id)} />
+                      onClose={() => handleClose(ev.id)}
+                      onExport={() => handleExport(ev)} />
                   ))}
                 </>
               )}
@@ -178,7 +263,8 @@ export function EventsPage() {
                 <>
                   <p className="section-title" style={{ marginTop: 24 }}>Geschlossen</p>
                   {closed.map((ev) => (
-                    <EventRow key={ev.id} ev={ev} busy={!!busy[ev.id]} />
+                    <EventRow key={ev.id} ev={ev} busy={!!busy[ev.id]}
+                      onExport={() => handleExport(ev)} />
                   ))}
                 </>
               )}
@@ -197,9 +283,10 @@ interface RowProps {
   onDeactivate?: () => void;
   onClose?: () => void;
   onAdminLogin?: () => void;
+  onExport?: () => void;
 }
 
-function EventRow({ ev, busy, onActivate, onDeactivate, onClose, onAdminLogin }: RowProps) {
+function EventRow({ ev, busy, onActivate, onDeactivate, onClose, onAdminLogin, onExport }: RowProps) {
   const status = getStatus(ev);
   const cardClass = [
     "event-card",
@@ -216,7 +303,7 @@ function EventRow({ ev, busy, onActivate, onDeactivate, onClose, onAdminLogin }:
         <span style={{ fontWeight: 600 }}>{ev.eventName}</span>
         <span className="muted" style={{ fontSize: 12 }}>#{ev.id}</span>
       </div>
-      <p className="muted" style={{ fontSize: 13, marginBottom: onActivate || onDeactivate || onAdminLogin ? 12 : 0 }}>
+      <p className="muted" style={{ fontSize: 13, marginBottom: onActivate || onDeactivate || onAdminLogin || onExport ? 12 : 0 }}>
         Admin: {ev.adminUsername}
         {ev.closedAt && (
           <span style={{ marginLeft: 10 }}>
@@ -224,7 +311,7 @@ function EventRow({ ev, busy, onActivate, onDeactivate, onClose, onAdminLogin }:
           </span>
         )}
       </p>
-      {(onActivate || onDeactivate || onAdminLogin) && (
+      {(onActivate || onDeactivate || onAdminLogin || onExport) && (
         <div style={{ display: "flex", gap: 8 }}>
           {onAdminLogin && (
             <button className="btn-primary" disabled={busy}
@@ -240,6 +327,11 @@ function EventRow({ ev, busy, onActivate, onDeactivate, onClose, onAdminLogin }:
           {onDeactivate && (
             <button className="btn-ghost" disabled={busy} onClick={onDeactivate}>
               {busy ? "..." : "Deaktivieren"}
+            </button>
+          )}
+          {onExport && (
+            <button className="btn-ghost" disabled={busy} onClick={onExport}>
+              {busy ? "..." : "Exportieren"}
             </button>
           )}
           {onClose && (

--- a/apps/api/src/domain/event-backup-store.ts
+++ b/apps/api/src/domain/event-backup-store.ts
@@ -1,0 +1,402 @@
+import Database from "better-sqlite3";
+import type { EventBackupData, EventBackupEvent, EventBackupFile } from "@bstoema/shared-types";
+import { ApiError } from "./api-error";
+import type { EventRecord, EventStore } from "./event-store";
+
+// Full-fidelity export/import of whole events. The export walks every domain
+// table of an event database (plus the control-DB metadata) into a portable
+// JSON structure; the import recreates it as a brand-new inactive event with
+// the original row ids preserved — safe because the target event DB is always
+// freshly created and empty. PrintQueue and Announcements are deliberately
+// left out: both are transient operational state, not event content.
+
+export class EventBackupStore {
+  constructor(private readonly eventStore: EventStore) {}
+
+  // Union of every store's lazily-created DDL, so exporting a young event that
+  // never touched some domain (and importing into a fresh DB) always finds the
+  // tables it reads/writes.
+  private ensureBackupSchema(db: Database.Database) {
+    db.exec(`
+      CREATE TABLE IF NOT EXISTS Users (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        username TEXT NOT NULL,
+        isLocked INTEGER NOT NULL DEFAULT 0
+      );
+
+      CREATE UNIQUE INDEX IF NOT EXISTS Users_username_key ON Users(username);
+
+      CREATE TABLE IF NOT EXISTS Tables (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        name TEXT NOT NULL,
+        weight INTEGER NOT NULL DEFAULT 0,
+        isLocked INTEGER NOT NULL DEFAULT 0
+      );
+
+      CREATE TABLE IF NOT EXISTS MenuCategories (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        name TEXT NOT NULL,
+        description TEXT NOT NULL DEFAULT '',
+        isLocked INTEGER NOT NULL DEFAULT 0,
+        weight INTEGER NOT NULL DEFAULT 0,
+        printer_id INTEGER,
+        orderDisplay_id INTEGER
+      );
+
+      CREATE TABLE IF NOT EXISTS MenuItems (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        name TEXT NOT NULL,
+        description TEXT NOT NULL DEFAULT '',
+        weight INTEGER NOT NULL DEFAULT 0,
+        price REAL NOT NULL DEFAULT 0,
+        isLocked INTEGER NOT NULL DEFAULT 0,
+        menuCategory_id INTEGER NOT NULL
+      );
+
+      CREATE TABLE IF NOT EXISTS StockItems (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        name TEXT NOT NULL,
+        quantity INTEGER NOT NULL DEFAULT 0
+      );
+
+      CREATE TABLE IF NOT EXISTS StockItemMenuItem (
+        stockItem_id INTEGER NOT NULL,
+        menuItem_id INTEGER NOT NULL,
+        quantityRequired INTEGER NOT NULL,
+        PRIMARY KEY (stockItem_id, menuItem_id)
+      );
+
+      CREATE TABLE IF NOT EXISTS Orders (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        timestamp TEXT NOT NULL,
+        table_id INTEGER NOT NULL,
+        user_id INTEGER NOT NULL
+      );
+
+      CREATE INDEX IF NOT EXISTS Orders_table_id_idx ON Orders(table_id);
+      CREATE INDEX IF NOT EXISTS Orders_user_id_idx ON Orders(user_id);
+      CREATE INDEX IF NOT EXISTS Orders_timestamp_idx ON Orders(timestamp);
+
+      CREATE TABLE IF NOT EXISTS OrderItems (
+        order_id INTEGER NOT NULL,
+        menuItem_id INTEGER NOT NULL,
+        quantity INTEGER NOT NULL,
+        specialRequests TEXT NOT NULL DEFAULT '',
+        PRIMARY KEY (order_id, menuItem_id)
+      );
+
+      CREATE INDEX IF NOT EXISTS OrderItems_menuItem_id_idx ON OrderItems(menuItem_id);
+      CREATE INDEX IF NOT EXISTS OrderItems_order_id_idx ON OrderItems(order_id);
+
+      CREATE TABLE IF NOT EXISTS Configurations (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        name TEXT NOT NULL,
+        value TEXT NOT NULL
+      );
+
+      CREATE UNIQUE INDEX IF NOT EXISTS Configurations_name_key ON Configurations(name);
+
+      CREATE TABLE IF NOT EXISTS Printers (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        name TEXT NOT NULL,
+        ipAddress TEXT NOT NULL,
+        connectionDetails TEXT NOT NULL DEFAULT ''
+      );
+
+      CREATE UNIQUE INDEX IF NOT EXISTS Printers_name_key ON Printers(name);
+
+      CREATE TABLE IF NOT EXISTS OrderDisplays (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        name TEXT NOT NULL,
+        ipAddress TEXT NOT NULL,
+        connectionDetails TEXT NOT NULL DEFAULT ''
+      );
+
+      CREATE UNIQUE INDEX IF NOT EXISTS OrderDisplays_name_key ON OrderDisplays(name);
+    `);
+  }
+
+  // Rows are read in id order (configurations by name) so exports of identical
+  // data are byte-for-byte comparable.
+  private readEventData(dbFilePath: string): EventBackupData {
+    const db = new Database(dbFilePath);
+    try {
+      this.ensureBackupSchema(db);
+
+      const users = (
+        db.prepare("SELECT id, username, isLocked FROM Users ORDER BY id").all() as Array<{
+          id: number;
+          username: string;
+          isLocked: number;
+        }>
+      ).map((r) => ({ id: r.id, username: r.username, isLocked: r.isLocked === 1 }));
+
+      const tables = (
+        db.prepare("SELECT id, name, weight, isLocked FROM Tables ORDER BY id").all() as Array<{
+          id: number;
+          name: string;
+          weight: number;
+          isLocked: number;
+        }>
+      ).map((r) => ({ id: r.id, name: r.name, weight: r.weight, isLocked: r.isLocked === 1 }));
+
+      const menuCategories = (
+        db
+          .prepare(
+            "SELECT id, name, description, isLocked, weight, printer_id, orderDisplay_id FROM MenuCategories ORDER BY id"
+          )
+          .all() as Array<{
+          id: number;
+          name: string;
+          description: string;
+          isLocked: number;
+          weight: number;
+          printer_id: number | null;
+          orderDisplay_id: number | null;
+        }>
+      ).map((r) => ({
+        id: r.id,
+        name: r.name,
+        description: r.description,
+        isLocked: r.isLocked === 1,
+        weight: r.weight,
+        printerId: r.printer_id,
+        orderDisplayId: r.orderDisplay_id,
+      }));
+
+      const menuItems = (
+        db
+          .prepare(
+            "SELECT id, name, description, weight, price, isLocked, menuCategory_id FROM MenuItems ORDER BY id"
+          )
+          .all() as Array<{
+          id: number;
+          name: string;
+          description: string;
+          weight: number;
+          price: number;
+          isLocked: number;
+          menuCategory_id: number;
+        }>
+      ).map((r) => ({
+        id: r.id,
+        name: r.name,
+        description: r.description,
+        weight: r.weight,
+        price: r.price,
+        isLocked: r.isLocked === 1,
+        menuCategoryId: r.menuCategory_id,
+      }));
+
+      const stockItems = db
+        .prepare("SELECT id, name, quantity FROM StockItems ORDER BY id")
+        .all() as Array<{ id: number; name: string; quantity: number }>;
+
+      const stockItemMenuItems = (
+        db
+          .prepare(
+            "SELECT stockItem_id, menuItem_id, quantityRequired FROM StockItemMenuItem ORDER BY stockItem_id, menuItem_id"
+          )
+          .all() as Array<{
+          stockItem_id: number;
+          menuItem_id: number;
+          quantityRequired: number;
+        }>
+      ).map((r) => ({
+        stockItemId: r.stockItem_id,
+        menuItemId: r.menuItem_id,
+        quantityRequired: r.quantityRequired,
+      }));
+
+      const orders = (
+        db.prepare("SELECT id, timestamp, table_id, user_id FROM Orders ORDER BY id").all() as Array<{
+          id: number;
+          timestamp: string;
+          table_id: number;
+          user_id: number;
+        }>
+      ).map((r) => ({ id: r.id, timestamp: r.timestamp, tableId: r.table_id, userId: r.user_id }));
+
+      const orderItems = (
+        db
+          .prepare(
+            "SELECT order_id, menuItem_id, quantity, specialRequests FROM OrderItems ORDER BY order_id, menuItem_id"
+          )
+          .all() as Array<{
+          order_id: number;
+          menuItem_id: number;
+          quantity: number;
+          specialRequests: string;
+        }>
+      ).map((r) => ({
+        orderId: r.order_id,
+        menuItemId: r.menuItem_id,
+        quantity: r.quantity,
+        specialRequests: r.specialRequests,
+      }));
+
+      const configurations = db
+        .prepare("SELECT name, value FROM Configurations ORDER BY name")
+        .all() as Array<{ name: string; value: string }>;
+
+      const printers = db
+        .prepare("SELECT id, name, ipAddress, connectionDetails FROM Printers ORDER BY id")
+        .all() as Array<{ id: number; name: string; ipAddress: string; connectionDetails: string }>;
+
+      const orderDisplays = db
+        .prepare("SELECT id, name, ipAddress, connectionDetails FROM OrderDisplays ORDER BY id")
+        .all() as Array<{ id: number; name: string; ipAddress: string; connectionDetails: string }>;
+
+      return {
+        users,
+        tables,
+        menuCategories,
+        menuItems,
+        stockItems,
+        stockItemMenuItems,
+        orders,
+        orderItems,
+        configurations,
+        printers,
+        orderDisplays,
+      };
+    } finally {
+      db.close();
+    }
+  }
+
+  private exportEvent(eventId: number): EventBackupEvent {
+    const meta = this.eventStore.getEventBackupMeta(eventId);
+    return {
+      eventName: meta.eventName,
+      createdAt: meta.createdAt,
+      closedAt: meta.closedAt ?? undefined,
+      adminUsername: meta.adminUsername,
+      adminPasswordHash: meta.adminPasswordHash,
+      eventPasscode: meta.eventPasscode,
+      eventPasscodeHash: meta.eventPasscodeHash,
+      data: this.readEventData(meta.dbFilePath),
+    };
+  }
+
+  /** Exports the given events (or all events when omitted) as one backup file. */
+  exportFile(eventIds?: number[]): EventBackupFile {
+    const ids = eventIds ?? this.eventStore.listAllEvents().map((event) => event.id);
+    return {
+      kind: "bstoema-event-backup",
+      formatVersion: 1,
+      exportedAt: new Date().toISOString(),
+      events: ids.map((id) => this.exportEvent(id)),
+    };
+  }
+
+  // The imported event name must be unique; a collision gets a " (Import)" /
+  // " (Import 2)" ... suffix instead of failing, so restoring next to the
+  // original (e.g. to compare) just works.
+  private resolveFreeEventName(eventName: string) {
+    if (!this.eventStore.eventNameExists(eventName)) {
+      return eventName;
+    }
+
+    for (let attempt = 1; ; attempt += 1) {
+      const candidate = attempt === 1 ? `${eventName} (Import)` : `${eventName} (Import ${attempt})`;
+      if (!this.eventStore.eventNameExists(candidate)) {
+        return candidate;
+      }
+    }
+  }
+
+  private writeEventData(dbFilePath: string, data: EventBackupData) {
+    const db = new Database(dbFilePath);
+    try {
+      this.ensureBackupSchema(db);
+
+      const insUser = db.prepare("INSERT INTO Users (id, username, isLocked) VALUES (?, ?, ?)");
+      const insTable = db.prepare("INSERT INTO Tables (id, name, weight, isLocked) VALUES (?, ?, ?, ?)");
+      const insCategory = db.prepare(
+        "INSERT INTO MenuCategories (id, name, description, isLocked, weight, printer_id, orderDisplay_id) VALUES (?, ?, ?, ?, ?, ?, ?)"
+      );
+      const insItem = db.prepare(
+        "INSERT INTO MenuItems (id, name, description, weight, price, isLocked, menuCategory_id) VALUES (?, ?, ?, ?, ?, ?, ?)"
+      );
+      const insStock = db.prepare("INSERT INTO StockItems (id, name, quantity) VALUES (?, ?, ?)");
+      const insStockLink = db.prepare(
+        "INSERT INTO StockItemMenuItem (stockItem_id, menuItem_id, quantityRequired) VALUES (?, ?, ?)"
+      );
+      const insOrder = db.prepare("INSERT INTO Orders (id, timestamp, table_id, user_id) VALUES (?, ?, ?, ?)");
+      const insOrderItem = db.prepare(
+        "INSERT INTO OrderItems (order_id, menuItem_id, quantity, specialRequests) VALUES (?, ?, ?, ?)"
+      );
+      const insConfig = db.prepare("INSERT INTO Configurations (name, value) VALUES (?, ?)");
+      const insPrinter = db.prepare(
+        "INSERT INTO Printers (id, name, ipAddress, connectionDetails) VALUES (?, ?, ?, ?)"
+      );
+      const insDisplay = db.prepare(
+        "INSERT INTO OrderDisplays (id, name, ipAddress, connectionDetails) VALUES (?, ?, ?, ?)"
+      );
+
+      db.transaction(() => {
+        for (const u of data.users) insUser.run(u.id, u.username, u.isLocked ? 1 : 0);
+        for (const t of data.tables) insTable.run(t.id, t.name, t.weight, t.isLocked ? 1 : 0);
+        for (const p of data.printers) insPrinter.run(p.id, p.name, p.ipAddress, p.connectionDetails);
+        for (const d of data.orderDisplays) insDisplay.run(d.id, d.name, d.ipAddress, d.connectionDetails);
+        for (const c of data.menuCategories) {
+          insCategory.run(c.id, c.name, c.description, c.isLocked ? 1 : 0, c.weight, c.printerId, c.orderDisplayId);
+        }
+        for (const i of data.menuItems) {
+          insItem.run(i.id, i.name, i.description, i.weight, i.price, i.isLocked ? 1 : 0, i.menuCategoryId);
+        }
+        for (const s of data.stockItems) insStock.run(s.id, s.name, s.quantity);
+        for (const l of data.stockItemMenuItems) insStockLink.run(l.stockItemId, l.menuItemId, l.quantityRequired);
+        for (const o of data.orders) insOrder.run(o.id, o.timestamp, o.tableId, o.userId);
+        for (const oi of data.orderItems) {
+          insOrderItem.run(oi.orderId, oi.menuItemId, oi.quantity, oi.specialRequests);
+        }
+        for (const c of data.configurations) insConfig.run(c.name, c.value);
+      })();
+    } finally {
+      db.close();
+    }
+  }
+
+  /**
+   * Imports every event in the backup file as a new, inactive event.
+   * All-or-nothing: if any event fails, the ones created earlier in the same
+   * call are deleted again so a broken file never leaves partial state behind.
+   */
+  importFile(file: EventBackupFile): EventRecord[] {
+    const created: EventRecord[] = [];
+
+    try {
+      for (const backupEvent of file.events) {
+        const event = this.eventStore.createEventFromBackup({
+          eventName: this.resolveFreeEventName(backupEvent.eventName),
+          createdAt: backupEvent.createdAt,
+          closedAt: backupEvent.closedAt,
+          adminUsername: backupEvent.adminUsername,
+          adminPasswordHash: backupEvent.adminPasswordHash,
+          eventPasscode: backupEvent.eventPasscode,
+          eventPasscodeHash: backupEvent.eventPasscodeHash,
+        });
+        created.push(event);
+        this.writeEventData(event.dbFilePath, backupEvent.data);
+      }
+    } catch (error) {
+      for (const event of created) {
+        try {
+          this.eventStore.deleteEvent(event.id);
+        } catch {
+          // Best-effort rollback; the original error is what matters.
+        }
+      }
+
+      if (error instanceof ApiError) {
+        throw error;
+      }
+
+      throw new ApiError(500, "EVENT_IMPORT_FAILED", "Failed to import event backup", error);
+    }
+
+    return created;
+  }
+}

--- a/apps/api/src/domain/event-store.ts
+++ b/apps/api/src/domain/event-store.ts
@@ -366,6 +366,123 @@ export class EventStore {
     return row.id;
   }
 
+  /**
+   * Returns everything the backup format needs from the control DB, including
+   * the stored credential hashes (never the plaintext admin password, which is
+   * not persisted anywhere).
+   */
+  getEventBackupMeta(eventId: number) {
+    const row = this.controlDb
+      .prepare(
+        `
+        SELECT eventName, createdAt, closedAt, adminUsername, adminPasswordHash,
+               eventPasscode, eventPasscodeHash, dbFilePath
+        FROM Events WHERE id = ?
+        `
+      )
+      .get(eventId) as
+      | {
+          eventName: string;
+          createdAt: string;
+          closedAt: string | null;
+          adminUsername: string;
+          adminPasswordHash: string;
+          eventPasscode: string | null;
+          eventPasscodeHash: string;
+          dbFilePath: string;
+        }
+      | undefined;
+
+    if (!row) {
+      throw new ApiError(404, "EVENT_NOT_FOUND", "Event not found");
+    }
+
+    return row;
+  }
+
+  eventNameExists(eventName: string) {
+    const row = this.controlDb
+      .prepare("SELECT id FROM Events WHERE eventName = ?")
+      .get(eventName) as { id: number } | undefined;
+    return row !== undefined;
+  }
+
+  /**
+   * Recreates an event row from backup metadata: credential hashes are stored
+   * verbatim and createdAt/closedAt are preserved. The event always starts
+   * inactive and gets a fresh, empty event database (the caller fills it).
+   */
+  createEventFromBackup(input: {
+    eventName: string;
+    createdAt: string;
+    closedAt?: string;
+    adminUsername: string;
+    adminPasswordHash: string;
+    eventPasscode: string | null;
+    eventPasscodeHash: string;
+  }): EventRecord {
+    const insert = this.controlDb.prepare(
+      `
+      INSERT INTO Events (eventName, eventPasscode, eventPasscodeHash, adminUsername, adminPasswordHash, dbFilePath, isActive, createdAt, closedAt)
+      VALUES (?, ?, ?, ?, ?, ?, 0, ?, ?)
+      `
+    );
+
+    let eventId: number | null = null;
+    let dbFilePath: string | null = null;
+
+    try {
+      const result = insert.run(
+        input.eventName,
+        input.eventPasscode,
+        input.eventPasscodeHash,
+        input.adminUsername,
+        input.adminPasswordHash,
+        "",
+        input.createdAt,
+        input.closedAt ?? null
+      );
+
+      eventId = Number(result.lastInsertRowid);
+      dbFilePath = this.createEventDatabase(eventId);
+      this.controlDb
+        .prepare("UPDATE Events SET dbFilePath = ? WHERE id = ?")
+        .run(dbFilePath, eventId);
+
+      const created = this.getEvent(eventId);
+      if (!created) {
+        throw new ApiError(500, "EVENT_IMPORT_FAILED", "Failed to load imported event");
+      }
+      return created;
+    } catch (error) {
+      if (eventId !== null) {
+        try {
+          if (dbFilePath) {
+            rmSync(dbFilePath, { force: true });
+          }
+        } catch {
+          // Ignore cleanup errors here; the control row is removed below if it exists.
+        }
+
+        try {
+          this.controlDb.prepare("DELETE FROM Events WHERE id = ?").run(eventId);
+        } catch {
+          // Ignore cleanup errors; the original error will be reported below.
+        }
+      }
+
+      if (this.isUniqueConstraintError(error)) {
+        throw new ApiError(409, "EVENT_ALREADY_EXISTS", "Event name already exists");
+      }
+
+      if (error instanceof ApiError) {
+        throw error;
+      }
+
+      throw new ApiError(500, "EVENT_IMPORT_FAILED", "Failed to import event", error);
+    }
+  }
+
   verifyEventAdminCredentials(eventId: number, username: string, password: string) {
     const row = this.controlDb
       .prepare("SELECT adminUsername, adminPasswordHash, closedAt FROM Events WHERE id = ?")

--- a/apps/api/src/domain/state.ts
+++ b/apps/api/src/domain/state.ts
@@ -1,6 +1,7 @@
 ﻿import { AnnouncementStore } from "./announcement-store";
 import { AuthStore } from "./auth-store";
 import { ConfigStore } from "./config-store";
+import { EventBackupStore } from "./event-backup-store";
 import { EventStore } from "./event-store";
 import { MenuStore } from "./menu-store";
 import { OrderStore } from "./order-store";
@@ -11,6 +12,7 @@ import { TableStore } from "./table-store";
 import { UserStore } from "./user-store";
 
 export const eventStore = new EventStore();
+export const eventBackupStore = new EventBackupStore(eventStore);
 export const announcementStore = new AnnouncementStore(eventStore);
 export const configStore = new ConfigStore(eventStore);
 export const userStore = new UserStore(eventStore);

--- a/apps/api/src/routes/admin-events.ts
+++ b/apps/api/src/routes/admin-events.ts
@@ -6,6 +6,10 @@
   AdminEventDeactivateResponseSchema,
   ApiErrorEnvelopeSchema,
   ActiveEventResponseSchema,
+  EventExportResponseSchema,
+  EventImportRequest,
+  EventImportRequestSchema,
+  EventImportResponseSchema,
   EventListResponseSchema,
   EventPasscodeResponseSchema,
   RotatePasscodeRequest,
@@ -14,7 +18,7 @@
 } from "@bstoema/shared-types";
 import type { FastifyInstance } from "fastify";
 import { z } from "zod";
-import { eventStore } from "../domain/state";
+import { eventBackupStore, eventStore } from "../domain/state";
 import { ApiError } from "../domain/api-error";
 
 const EventIdParamsSchema = z.object({
@@ -230,6 +234,87 @@ export function registerAdminEventRoutes(app: FastifyInstance) {
     async (request, reply) => {
       eventStore.deleteEvent(request.params.eventId);
       return reply.status(204).send();
+    }
+  );
+
+  // ---------------------------------------------------------------------------
+  // Backup / restore (master-scoped)
+  // ---------------------------------------------------------------------------
+
+  app.get(
+    "/admin/events/export",
+    {
+      config: {
+        requiresRole: "master",
+      },
+      schema: {
+        tags: ["admin-events"],
+        operationId: "adminEventsExportAll",
+        summary: "Alle Events als Backup exportieren",
+        description:
+          "Exportiert alle Events als eine portable Backup-Datei (volle Datentreue: Speisekarte, Tische, Kellner, Bestellungen, Lager, Konfiguration, Drucker/Displays).",
+        security: [{ bearerAuth: [] }],
+        response: {
+          200: EventExportResponseSchema,
+          401: ApiErrorEnvelopeSchema,
+          403: ApiErrorEnvelopeSchema,
+        },
+      },
+    },
+    async () => eventBackupStore.exportFile()
+  );
+
+  app.get<{ Params: EventIdParams }>(
+    "/admin/events/:eventId/export",
+    {
+      config: {
+        requiresRole: "master",
+      },
+      schema: {
+        tags: ["admin-events"],
+        operationId: "adminEventsExport",
+        summary: "Einzelnes Event als Backup exportieren",
+        description:
+          "Exportiert das angegebene Event als portable Backup-Datei (volle Datentreue: Speisekarte, Tische, Kellner, Bestellungen, Lager, Konfiguration, Drucker/Displays).",
+        security: [{ bearerAuth: [] }],
+        params: EventIdParamsSchema,
+        response: {
+          200: EventExportResponseSchema,
+          401: ApiErrorEnvelopeSchema,
+          403: ApiErrorEnvelopeSchema,
+          404: ApiErrorEnvelopeSchema,
+        },
+      },
+    },
+    async (request) => eventBackupStore.exportFile([request.params.eventId])
+  );
+
+  app.post<{ Body: EventImportRequest }>(
+    "/admin/events/import",
+    {
+      config: {
+        requiresRole: "master",
+      },
+      schema: {
+        tags: ["admin-events"],
+        operationId: "adminEventsImport",
+        summary: "Event-Backup importieren",
+        description:
+          "Importiert jedes Event der Backup-Datei als neues, inaktives Event. Bestehende Events werden nie ueberschrieben; bei Namenskollision wird ein ' (Import)'-Suffix angehaengt.",
+        security: [{ bearerAuth: [] }],
+        body: EventImportRequestSchema,
+        response: {
+          201: EventImportResponseSchema,
+          400: ApiErrorEnvelopeSchema,
+          401: ApiErrorEnvelopeSchema,
+          403: ApiErrorEnvelopeSchema,
+          500: ApiErrorEnvelopeSchema,
+        },
+      },
+    },
+    async (request, reply) => {
+      const created = eventBackupStore.importFile(request.body.backup);
+      return reply.status(201).send({ events: created.map(toEventDto) });
     }
   );
 

--- a/apps/api/src/routes/event-backup.test.ts
+++ b/apps/api/src/routes/event-backup.test.ts
@@ -1,0 +1,277 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { EventBackupFile } from "@bstoema/shared-types";
+import { buildApp } from "../app";
+import { hashPassword } from "../domain/password";
+import { eventStore } from "../domain/state";
+import { setupEventTestUtils } from "../test-utils/event-test-utils";
+
+const {
+  createEventPrefix,
+  createTestEvent,
+  createAppFixture,
+  configureMasterCredentials,
+  createAuthFixture,
+} = setupEventTestUtils(test, eventStore);
+
+// Builds a backup file fixture with every domain table populated. Rows are
+// listed in id order (configurations by name) to match the export ordering,
+// so an import → export roundtrip must reproduce `data` verbatim.
+function buildBackupFixture(eventName: string): EventBackupFile {
+  return {
+    kind: "bstoema-event-backup",
+    formatVersion: 1,
+    exportedAt: new Date().toISOString(),
+    events: [
+      {
+        eventName,
+        createdAt: "2026-06-01T10:00:00.000Z",
+        adminUsername: "backup-admin",
+        adminPasswordHash: hashPassword("backup-secret"),
+        eventPasscode: "backup-pass",
+        eventPasscodeHash: hashPassword("backup-pass"),
+        data: {
+          users: [
+            { id: 1, username: "anna", isLocked: false },
+            { id: 2, username: "ben", isLocked: true },
+          ],
+          tables: [
+            { id: 1, name: "Tisch 1", weight: 0, isLocked: false },
+            { id: 2, name: "Tisch 2", weight: 1, isLocked: false },
+          ],
+          menuCategories: [
+            {
+              id: 1,
+              name: "Getraenke",
+              description: "Kalt & warm",
+              isLocked: false,
+              weight: 0,
+              printerId: 1,
+              orderDisplayId: 1,
+            },
+            {
+              id: 2,
+              name: "Speisen",
+              description: "",
+              isLocked: false,
+              weight: 1,
+              printerId: null,
+              orderDisplayId: null,
+            },
+          ],
+          menuItems: [
+            {
+              id: 1,
+              name: "Cola",
+              description: "0.5l",
+              weight: 0,
+              price: 3.5,
+              isLocked: false,
+              menuCategoryId: 1,
+            },
+            {
+              id: 2,
+              name: "Schnitzel",
+              description: "mit Pommes",
+              weight: 0,
+              price: 12.9,
+              isLocked: false,
+              menuCategoryId: 2,
+            },
+          ],
+          stockItems: [{ id: 1, name: "Cola-Kiste", quantity: 24 }],
+          stockItemMenuItems: [{ stockItemId: 1, menuItemId: 1, quantityRequired: 1 }],
+          orders: [
+            { id: 1, timestamp: "2026-06-01T12:00:00.000Z", tableId: 1, userId: 1 },
+            { id: 2, timestamp: "2026-06-01T12:05:00.000Z", tableId: 2, userId: 2 },
+          ],
+          orderItems: [
+            { orderId: 1, menuItemId: 1, quantity: 2, specialRequests: "ohne Eis" },
+            { orderId: 1, menuItemId: 2, quantity: 1, specialRequests: "" },
+            { orderId: 2, menuItemId: 1, quantity: 1, specialRequests: "" },
+          ],
+          configurations: [
+            { name: "currency", value: "EUR" },
+            { name: "eventMotto", value: "Sommerfest" },
+          ],
+          printers: [{ id: 1, name: "Theke", ipAddress: "192.168.1.50", connectionDetails: "" }],
+          orderDisplays: [{ id: 1, name: "Kueche", ipAddress: "192.168.1.60", connectionDetails: "" }],
+        },
+      },
+    ],
+  };
+}
+
+test("import → export roundtrip restores an event with full fidelity", { concurrency: false }, async () => {
+  configureMasterCredentials();
+  const app = await createAppFixture(buildApp);
+  const auth = createAuthFixture(app);
+  const masterToken = await auth.loginMaster();
+
+  const eventName = createEventPrefix("backup-roundtrip");
+  const fixture = buildBackupFixture(eventName);
+  const importedIds: number[] = [];
+
+  try {
+    const importResponse = await app.inject({
+      method: "POST",
+      url: "/admin/events/import",
+      headers: { authorization: `Bearer ${masterToken}` },
+      payload: { backup: fixture },
+    });
+    assert.equal(importResponse.statusCode, 201);
+    const imported = importResponse.json().events as Array<{
+      id: number;
+      eventName: string;
+      adminUsername: string;
+      isActive: boolean;
+      createdAt: string;
+      closedAt?: string;
+    }>;
+    assert.equal(imported.length, 1);
+    importedIds.push(imported[0].id);
+
+    // No name collision on first import → original name and metadata preserved,
+    // event starts inactive.
+    assert.equal(imported[0].eventName, eventName);
+    assert.equal(imported[0].adminUsername, "backup-admin");
+    assert.equal(imported[0].isActive, false);
+    assert.equal(imported[0].createdAt, "2026-06-01T10:00:00.000Z");
+    assert.equal(imported[0].closedAt, undefined);
+
+    // Exporting the imported event must reproduce the fixture data verbatim.
+    const exportResponse = await app.inject({
+      method: "GET",
+      url: `/admin/events/${imported[0].id}/export`,
+      headers: { authorization: `Bearer ${masterToken}` },
+    });
+    assert.equal(exportResponse.statusCode, 200);
+    const exported = exportResponse.json() as EventBackupFile;
+    assert.equal(exported.kind, "bstoema-event-backup");
+    assert.equal(exported.formatVersion, 1);
+    assert.equal(exported.events.length, 1);
+    assert.equal(exported.events[0].eventName, eventName);
+    assert.equal(exported.events[0].adminUsername, "backup-admin");
+    assert.equal(exported.events[0].eventPasscode, "backup-pass");
+    assert.equal(exported.events[0].adminPasswordHash, fixture.events[0].adminPasswordHash);
+    assert.equal(exported.events[0].eventPasscodeHash, fixture.events[0].eventPasscodeHash);
+    assert.deepEqual(exported.events[0].data, fixture.events[0].data);
+
+    // The restored credential hashes must actually work for admin login.
+    const adminToken = await auth.loginAdmin({
+      eventId: imported[0].id,
+      username: "backup-admin",
+      password: "backup-secret",
+    });
+    assert.ok(adminToken);
+
+    // Re-importing the same file must not overwrite the existing event but
+    // create a renamed copy instead — twice, to cover the numbered suffix.
+    const secondImport = await app.inject({
+      method: "POST",
+      url: "/admin/events/import",
+      headers: { authorization: `Bearer ${masterToken}` },
+      payload: { backup: fixture },
+    });
+    assert.equal(secondImport.statusCode, 201);
+    const second = secondImport.json().events[0] as { id: number; eventName: string };
+    importedIds.push(second.id);
+    assert.equal(second.eventName, `${eventName} (Import)`);
+
+    const thirdImport = await app.inject({
+      method: "POST",
+      url: "/admin/events/import",
+      headers: { authorization: `Bearer ${masterToken}` },
+      payload: { backup: fixture },
+    });
+    assert.equal(thirdImport.statusCode, 201);
+    const third = thirdImport.json().events[0] as { id: number; eventName: string };
+    importedIds.push(third.id);
+    assert.equal(third.eventName, `${eventName} (Import 2)`);
+
+    // The original event still exists untouched next to its copies.
+    const originalExport = await app.inject({
+      method: "GET",
+      url: `/admin/events/${imported[0].id}/export`,
+      headers: { authorization: `Bearer ${masterToken}` },
+    });
+    assert.equal(originalExport.statusCode, 200);
+    assert.deepEqual(
+      (originalExport.json() as EventBackupFile).events[0].data,
+      fixture.events[0].data
+    );
+  } finally {
+    for (const id of importedIds) {
+      try {
+        eventStore.deleteEvent(id);
+      } catch {
+        // Already gone — nothing to clean up.
+      }
+    }
+  }
+});
+
+test("export-all includes fresh events with empty data and export is master-only", { concurrency: false }, async () => {
+  configureMasterCredentials();
+  const app = await createAppFixture(buildApp);
+  const auth = createAuthFixture(app);
+  const masterToken = await auth.loginMaster();
+
+  const eventName = createEventPrefix("backup-export-all");
+  const event = createTestEvent({
+    eventName,
+    eventPasscode: "pass",
+    adminUsername: "chef",
+    adminPassword: "secret",
+  });
+
+  // A brand-new event has no domain tables yet; export must still succeed.
+  const exportAll = await app.inject({
+    method: "GET",
+    url: "/admin/events/export",
+    headers: { authorization: `Bearer ${masterToken}` },
+  });
+  assert.equal(exportAll.statusCode, 200);
+  const file = exportAll.json() as EventBackupFile;
+  const entry = file.events.find((e) => e.eventName === eventName);
+  assert.ok(entry);
+  assert.deepEqual(entry.data.users, []);
+  assert.deepEqual(entry.data.orders, []);
+  assert.equal(entry.adminUsername, "chef");
+
+  // Event admins must not be able to pull full backups.
+  const adminToken = await auth.loginAdmin({
+    eventId: event.id,
+    username: "chef",
+    password: "secret",
+  });
+  const forbidden = await app.inject({
+    method: "GET",
+    url: `/admin/events/${event.id}/export`,
+    headers: { authorization: `Bearer ${adminToken}` },
+  });
+  assert.equal(forbidden.statusCode, 403);
+});
+
+test("export of a missing event returns 404 and malformed imports are rejected", { concurrency: false }, async () => {
+  configureMasterCredentials();
+  const app = await createAppFixture(buildApp);
+  const auth = createAuthFixture(app);
+  const masterToken = await auth.loginMaster();
+
+  const missingExport = await app.inject({
+    method: "GET",
+    url: "/admin/events/999999/export",
+    headers: { authorization: `Bearer ${masterToken}` },
+  });
+  assert.equal(missingExport.statusCode, 404);
+  assert.equal(missingExport.json().error.code, "EVENT_NOT_FOUND");
+
+  const badImport = await app.inject({
+    method: "POST",
+    url: "/admin/events/import",
+    headers: { authorization: `Bearer ${masterToken}` },
+    payload: { backup: { kind: "not-a-backup", formatVersion: 1, exportedAt: "x", events: [] } },
+  });
+  assert.equal(badImport.statusCode, 400);
+});

--- a/packages/api-client/src/routes/admin-events.ts
+++ b/packages/api-client/src/routes/admin-events.ts
@@ -4,6 +4,9 @@ import {
   AdminEventCreateRequestSchema,
   AdminEventCreateResponseSchema,
   AdminEventDeactivateResponseSchema,
+  EventExportResponseSchema,
+  EventImportRequestSchema,
+  EventImportResponseSchema,
   EventListResponseSchema,
   EventPasscodeResponseSchema,
   RotatePasscodeRequestSchema,
@@ -13,6 +16,9 @@ import {
   type AdminEventCreateRequest,
   type AdminEventCreateResponse,
   type AdminEventDeactivateResponse,
+  type EventBackupFile,
+  type EventExportResponse,
+  type EventImportResponse,
   type EventListResponse,
   type EventPasscodeResponse,
   type RotatePasscodeResponse,
@@ -32,6 +38,12 @@ export interface AdminEventsClient {
   getPasscode(): Promise<EventPasscodeResponse>;
   /** Rotates the passcode of the currently active event and returns the new value. */
   rotatePasscode(newPasscode: string): Promise<RotatePasscodeResponse>;
+  /** Exports one event as a portable full-fidelity backup file (master-scoped). */
+  exportEvent(eventId: number): Promise<EventExportResponse>;
+  /** Exports every event into a single backup file (master-scoped). */
+  exportAll(): Promise<EventExportResponse>;
+  /** Imports every event of a backup file as a new, inactive event (master-scoped). */
+  importBackup(backup: EventBackupFile): Promise<EventImportResponse>;
 }
 
 export function createAdminEventsClient(http: HttpTransport): AdminEventsClient {
@@ -69,6 +81,19 @@ export function createAdminEventsClient(http: HttpTransport): AdminEventsClient 
         RotatePasscodeResponseSchema,
         "/admin/event-passcode",
         RotatePasscodeRequestSchema.parse({ newPasscode }),
+      ),
+
+    exportEvent: (eventId) =>
+      http.get(EventExportResponseSchema, `/admin/events/${eventId}/export`),
+
+    exportAll: () =>
+      http.get(EventExportResponseSchema, "/admin/events/export"),
+
+    importBackup: (backup) =>
+      http.post(
+        EventImportResponseSchema,
+        "/admin/events/import",
+        EventImportRequestSchema.parse({ backup }),
       ),
   };
 }

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -990,6 +990,176 @@ export type RotatePasscodeRequest = z.infer<typeof RotatePasscodeRequestSchema>;
 export const RotatePasscodeResponseSchema = EventPasscodeResponseSchema;
 export type RotatePasscodeResponse = EventPasscodeResponse;
 
+// ─── Event backup / restore ──────────────────────────────────────────────────
+// A portable, full-fidelity snapshot of one or more events: the control-DB
+// metadata (including credential *hashes*, so logins survive a restore) plus
+// every domain table of the event database with original ids preserved.
+// Importing always creates brand-new inactive events — existing events are
+// never touched — so ids can be copied verbatim into the fresh event DB.
+
+export const EventBackupUserSchema = z
+  .object({
+    id: positiveInt,
+    username: nonEmptyString,
+    isLocked: z.boolean(),
+  })
+  .strict();
+export type EventBackupUser = z.infer<typeof EventBackupUserSchema>;
+
+export const EventBackupTableSchema = z
+  .object({
+    id: positiveInt,
+    name: z.string(),
+    weight: z.number().int(),
+    isLocked: z.boolean(),
+  })
+  .strict();
+export type EventBackupTable = z.infer<typeof EventBackupTableSchema>;
+
+export const EventBackupMenuCategorySchema = z
+  .object({
+    id: positiveInt,
+    name: z.string(),
+    description: z.string(),
+    isLocked: z.boolean(),
+    weight: z.number().int(),
+    printerId: positiveInt.nullable(),
+    orderDisplayId: positiveInt.nullable(),
+  })
+  .strict();
+export type EventBackupMenuCategory = z.infer<typeof EventBackupMenuCategorySchema>;
+
+export const EventBackupMenuItemSchema = z
+  .object({
+    id: positiveInt,
+    name: z.string(),
+    description: z.string(),
+    weight: z.number().int(),
+    price: z.number(),
+    isLocked: z.boolean(),
+    menuCategoryId: positiveInt,
+  })
+  .strict();
+export type EventBackupMenuItem = z.infer<typeof EventBackupMenuItemSchema>;
+
+export const EventBackupStockItemSchema = z
+  .object({
+    id: positiveInt,
+    name: z.string(),
+    quantity: z.number().int(),
+  })
+  .strict();
+export type EventBackupStockItem = z.infer<typeof EventBackupStockItemSchema>;
+
+export const EventBackupStockLinkSchema = z
+  .object({
+    stockItemId: positiveInt,
+    menuItemId: positiveInt,
+    quantityRequired: z.number().int(),
+  })
+  .strict();
+export type EventBackupStockLink = z.infer<typeof EventBackupStockLinkSchema>;
+
+export const EventBackupOrderSchema = z
+  .object({
+    id: positiveInt,
+    timestamp: z.string(),
+    tableId: positiveInt,
+    userId: positiveInt,
+  })
+  .strict();
+export type EventBackupOrder = z.infer<typeof EventBackupOrderSchema>;
+
+export const EventBackupOrderItemSchema = z
+  .object({
+    orderId: positiveInt,
+    menuItemId: positiveInt,
+    quantity: z.number().int(),
+    specialRequests: z.string(),
+  })
+  .strict();
+export type EventBackupOrderItem = z.infer<typeof EventBackupOrderItemSchema>;
+
+export const EventBackupConfigurationSchema = z
+  .object({
+    name: z.string(),
+    value: z.string(),
+  })
+  .strict();
+export type EventBackupConfiguration = z.infer<typeof EventBackupConfigurationSchema>;
+
+export const EventBackupPrinterSchema = z
+  .object({
+    id: positiveInt,
+    name: z.string(),
+    ipAddress: z.string(),
+    connectionDetails: z.string(),
+  })
+  .strict();
+export type EventBackupPrinter = z.infer<typeof EventBackupPrinterSchema>;
+
+export const EventBackupOrderDisplaySchema = EventBackupPrinterSchema;
+export type EventBackupOrderDisplay = EventBackupPrinter;
+
+export const EventBackupDataSchema = z
+  .object({
+    users: z.array(EventBackupUserSchema),
+    tables: z.array(EventBackupTableSchema),
+    menuCategories: z.array(EventBackupMenuCategorySchema),
+    menuItems: z.array(EventBackupMenuItemSchema),
+    stockItems: z.array(EventBackupStockItemSchema),
+    stockItemMenuItems: z.array(EventBackupStockLinkSchema),
+    orders: z.array(EventBackupOrderSchema),
+    orderItems: z.array(EventBackupOrderItemSchema),
+    configurations: z.array(EventBackupConfigurationSchema),
+    printers: z.array(EventBackupPrinterSchema),
+    orderDisplays: z.array(EventBackupOrderDisplaySchema),
+  })
+  .strict();
+export type EventBackupData = z.infer<typeof EventBackupDataSchema>;
+
+export const EventBackupEventSchema = z
+  .object({
+    eventName: nonEmptyString,
+    createdAt: z.string().datetime(),
+    closedAt: z.string().datetime().optional(),
+    adminUsername: nonEmptyString,
+    adminPasswordHash: nonEmptyString,
+    // Pre-migration events never stored the plaintext passcode; null keeps them exportable.
+    eventPasscode: z.string().nullable(),
+    eventPasscodeHash: nonEmptyString,
+    data: EventBackupDataSchema,
+  })
+  .strict();
+export type EventBackupEvent = z.infer<typeof EventBackupEventSchema>;
+
+export const EventBackupFileSchema = z
+  .object({
+    kind: z.literal("bstoema-event-backup"),
+    formatVersion: z.literal(1),
+    exportedAt: z.string(),
+    events: z.array(EventBackupEventSchema),
+  })
+  .strict();
+export type EventBackupFile = z.infer<typeof EventBackupFileSchema>;
+
+export const EventExportResponseSchema = EventBackupFileSchema;
+export type EventExportResponse = EventBackupFile;
+
+export const EventImportRequestSchema = z
+  .object({
+    backup: EventBackupFileSchema,
+  })
+  .strict();
+export type EventImportRequest = z.infer<typeof EventImportRequestSchema>;
+
+export const EventImportResponseSchema = z
+  .object({
+    events: z.array(EventDtoSchema),
+  })
+  .strict();
+export type EventImportResponse = z.infer<typeof EventImportResponseSchema>;
+
 export const HostInfoResponseSchema = z
   .object({
     localIp: z.string(),


### PR DESCRIPTION
Closes #156

Full-fidelity export/import of whole events so local data survives uninstalls, machine changes and mistakes.

## What's in the backup

A versioned JSON file (`kind: "bstoema-event-backup"`, `formatVersion: 1`) holding one or more events:

- **Control-DB metadata**: event name, createdAt/closedAt, admin username, and the credential *hashes* (admin password hash + passcode hash/plaintext passcode as already stored) — so admin/waiter logins keep working after a restore. The plaintext admin password is never stored anywhere and is not in the file.
- **Every domain table** of the event database with original ids preserved: users, tables, menu categories/items, stock items + links, orders + order items, configurations, and printers/order displays (kept so category routing survives). `PrintQueue` and `Announcements` are deliberately excluded as transient operational state.

## API (master-scoped)

- `GET /admin/events/export` — all events as one backup file
- `GET /admin/events/:eventId/export` — a single event
- `POST /admin/events/import` — each event in the file becomes a **new, inactive** event with a fresh event DB; ids are copied verbatim into the empty DB. Existing events are never overwritten: name collisions get a ` (Import)` / ` (Import 2)` suffix. Import is all-or-nothing — a failure rolls back every event created by that call.

New `EventBackupStore` domain store; `EventStore` gains `getEventBackupMeta`, `eventNameExists` and `createEventFromBackup` (stores hashes verbatim, preserves createdAt/closedAt, always starts inactive).

## api-client

`adminEvents.exportEvent(id)`, `adminEvents.exportAll()`, `adminEvents.importBackup(file)`.

## Admin desktop (events page)

- "Exportieren" button on every event card (active, inactive **and closed**)
- "Alle exportieren" + "Importieren" in the page header
- Reuses the Tauri dialog / browser-fallback file helpers from #135; import reloads the list and shows a result notice

## Tests

`event-backup.test.ts` (3 tests, plus full suite 56/56 green):
- import → export roundtrip reproduces the backup data **verbatim** (deep-equal), admin login works on the restored event with the original password, re-imports create renamed copies instead of overwriting
- export-all handles brand-new events whose domain tables don't exist yet; event admins get 403 (master-only)
- 404 for missing event export, 400 for malformed backup files

🤖 Generated with [Claude Code](https://claude.com/claude-code)