### PR TITLE
chore: release v1.2.0

### DIFF
--- a/apps/admin-desktop/package.json
+++ b/apps/admin-desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "appsadmin-desktop",
   "private": true,
-  "version": "1.1.1",
+  "version": "1.2.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/apps/admin-desktop/src-tauri/Cargo.toml
+++ b/apps/admin-desktop/src-tauri/Cargo.toml
@@ -2,7 +2,7 @@
 name = "appsadmin-desktop"
 # Auto-synced from the root package.json by scripts/sync-versions.mjs.
 # Do not edit by hand — bump "version" in the root package.json instead.
-version = "1.1.1"
+version = "1.2.0"
 description = "Desktop App for BstöMa"
 authors = ["Elias Pöschl (@DeltaAT)"]
 edition = "2021"

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "api",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "",
   "main": "index.js",
   "type": "module",

--- a/apps/waiter-web/package.json
+++ b/apps/waiter-web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "waiter-web",
   "private": true,
-  "version": "1.1.1",
+  "version": "1.2.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bstoema",
   "private": true,
-  "version": "1.1.1",
+  "version": "1.2.0",
   "workspaces": [
     "apps/*",
     "packages/*"

--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bstoema/api-client",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/auth-context/package.json
+++ b/packages/auth-context/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bstoema/auth-context",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/shared-types/package.json
+++ b/packages/shared-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bstoema/shared-types",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
Version bump to v1.2.0 across all workspace manifests (`pnpm version:sync`).

Changes since v1.1.1:
- feat(api/admin-desktop): event backup & restore — export/import full event data (#156, #157)

🤖 Generated with [Claude Code](https://claude.com/claude-code)