### PR TITLE
feat(admin-desktop): SVG icons instead of emojis

### DIFF
--- a/apps/admin-desktop/package.json
+++ b/apps/admin-desktop/package.json
@@ -19,6 +19,7 @@
     "@tauri-apps/plugin-fs": "^2.5.1",
     "@tauri-apps/plugin-opener": "^2",
     "@tauri-apps/plugin-store": "^2",
+    "lucide-react": "^1.33.0",
     "qrcode": "^1.5.4",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",

--- a/apps/admin-desktop/src/App.css
+++ b/apps/admin-desktop/src/App.css
@@ -341,6 +341,7 @@ html, body, #root {
   display: inline-flex;
   align-items: center;
   justify-content: center;
+  gap: 6px;
   padding: 9px 18px;
   width: 100%;
   background: var(--color-brand);
@@ -365,6 +366,7 @@ html, body, #root {
 .btn-secondary {
   display: inline-flex;
   align-items: center;
+  gap: 6px;
   padding: 7px 14px;
   background: var(--color-surface);
   color: var(--color-text);
@@ -1154,7 +1156,7 @@ html, body, #root {
 .printers-col-status  { font-size: 12px; white-space: nowrap; }
 .printers-col-actions { display: flex; align-items: center; gap: 4px; justify-content: flex-end; }
 
-.printers-status { font-size: 12px; font-weight: 600; }
+.printers-status { display: inline-flex; align-items: center; gap: 4px; font-size: 12px; font-weight: 600; }
 .printers-status--pending { color: var(--color-muted); }
 .printers-status--ok      { color: #16a34a; }
 .printers-status--error   { color: #dc2626; }
@@ -1339,6 +1341,9 @@ html, body, #root {
 }
 
 .config-saved {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
   font-size: 12px;
   font-weight: 600;
   color: #16a34a;
@@ -1638,7 +1643,8 @@ html, body, #root {
 }
 
 .menu-items-empty__icon {
-  font-size: 36px;
+  display: flex;
+  color: var(--color-muted);
   line-height: 1;
   opacity: 0.5;
 }
@@ -1696,7 +1702,9 @@ html, body, #root {
 }
 
 .menu-item-stock-badge {
-  font-size: 13px;
+  display: inline-flex;
+  align-items: center;
+  color: var(--color-muted);
   flex-shrink: 0;
 }
 
@@ -1975,7 +1983,7 @@ html, body, #root {
 .orders-col-table  { font-size: 13px; font-weight: 500; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .orders-col-waiter { font-size: 13px; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .orders-col-count  { font-size: 13px; font-weight: 600; text-align: right; font-variant-numeric: tabular-nums; }
-.orders-col-toggle { font-size: 12px; color: var(--color-muted); text-align: center; }
+.orders-col-toggle { display: flex; align-items: center; justify-content: center; color: var(--color-muted); }
 
 .orders-detail {
   padding: 12px 18px 16px 18px;

--- a/apps/admin-desktop/src/pages/ConfigPage.tsx
+++ b/apps/admin-desktop/src/pages/ConfigPage.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react";
+import { Check } from "lucide-react";
 import type { ConfigValues } from "@bstoema/shared-types";
 import { useApiClient } from "../contexts/ApiClientContext";
 
@@ -327,7 +328,7 @@ function ConfigRow({ configKey, serverValue, known, onSave }: ConfigRowProps) {
 
       <div className="config-row__actions">
         {save.status === "ok" && (
-          <span className="config-saved">✓ Gespeichert</span>
+          <span className="config-saved"><Check size={14} aria-hidden /> Gespeichert</span>
         )}
         <button
           type="button"

--- a/apps/admin-desktop/src/pages/MenuItemsPage.tsx
+++ b/apps/admin-desktop/src/pages/MenuItemsPage.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react";
+import { Lock, Package, Pencil, Trash2, Unlock } from "lucide-react";
 import { useApiClient } from "../contexts/ApiClientContext";
 import type { MenuCategoryDto, MenuItemDto } from "@bstoema/shared-types";
 
@@ -612,7 +613,7 @@ export function MenuItemsPage() {
               <span className="items-col-stock">
                 {itemsWithStock.has(item.id) ? (
                   <span className="badge-stock" title="Hat Lageranforderungen">
-                    🧺
+                    <Package size={14} aria-hidden />
                   </span>
                 ) : null}
               </span>
@@ -631,21 +632,21 @@ export function MenuItemsPage() {
                   title={item.isLocked ? "Entsperren" : "Sperren"}
                   onClick={() => handleToggleLock(item)}
                 >
-                  {item.isLocked ? "🔓" : "🔒"}
+                  {item.isLocked ? <Unlock size={15} aria-hidden /> : <Lock size={15} aria-hidden />}
                 </button>
                 <button
                   className="btn-icon"
                   title="Bearbeiten"
                   onClick={() => openEdit(item)}
                 >
-                  ✏️
+                  <Pencil size={15} aria-hidden />
                 </button>
                 <button
                   className="btn-icon btn-icon--danger"
                   title="Löschen"
                   onClick={() => openDelete(item)}
                 >
-                  🗑️
+                  <Trash2 size={15} aria-hidden />
                 </button>
               </span>
             </div>

--- a/apps/admin-desktop/src/pages/MenuPage.tsx
+++ b/apps/admin-desktop/src/pages/MenuPage.tsx
@@ -1,4 +1,17 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  ChevronDown,
+  ChevronUp,
+  ClipboardList,
+  Download,
+  Lock,
+  Package,
+  Pencil,
+  Trash2,
+  Unlock,
+  Upload,
+  UtensilsCrossed,
+} from "lucide-react";
 import { useApiClient } from "../contexts/ApiClientContext";
 import { ApiConflictError } from "@bstoema/api-client";
 import { MenuExportSchema } from "@bstoema/shared-types";
@@ -760,7 +773,7 @@ export function MenuPage() {
             disabled={ioBusy}
             title="Speisekarte als Datei exportieren"
           >
-            ⭳ Exportieren
+            <Download size={14} aria-hidden /> Exportieren
           </button>
           <button
             className="btn-secondary"
@@ -769,7 +782,7 @@ export function MenuPage() {
             disabled={ioBusy}
             title="Speisekarte aus einer Datei importieren"
           >
-            ⭱ Importieren
+            <Upload size={14} aria-hidden /> Importieren
           </button>
         </div>
       </div>
@@ -835,13 +848,13 @@ export function MenuPage() {
                       disabled={idx === 0 || reordering}
                       onClick={() => moveCategory(idx, -1)}
                       title="Nach oben"
-                    >▲</button>
+                    ><ChevronUp size={12} aria-hidden /></button>
                     <button
                       className="menu-reorder-btn"
                       disabled={idx === categories.length - 1 || reordering}
                       onClick={() => moveCategory(idx, 1)}
                       title="Nach unten"
-                    >▼</button>
+                    ><ChevronDown size={12} aria-hidden /></button>
                   </div>
 
                   {/* Info */}
@@ -864,20 +877,20 @@ export function MenuPage() {
                       title={cat.isLocked ? "Entsperren" : "Sperren"}
                       onClick={() => handleCatToggleLock(cat)}
                     >
-                      {cat.isLocked ? "🔓" : "🔒"}
+                      {cat.isLocked ? <Unlock size={13} aria-hidden /> : <Lock size={13} aria-hidden />}
                     </button>
                     <button
                       className="btn-icon"
                       style={{ width: 26, height: 26, fontSize: 12 }}
                       title="Bearbeiten"
                       onClick={() => { setCatSaveErr(null); setCatEdit(cat); }}
-                    >✏️</button>
+                    ><Pencil size={13} aria-hidden /></button>
                     <button
                       className="btn-icon btn-icon--danger"
                       style={{ width: 26, height: 26, fontSize: 12 }}
                       title="Löschen"
                       onClick={() => { setCatDeleteErr(null); setCatDelete(cat); }}
-                    >🗑️</button>
+                    ><Trash2 size={13} aria-hidden /></button>
                   </div>
                 </div>
               ))
@@ -928,7 +941,7 @@ export function MenuPage() {
             {/* Empty state — no categories yet */}
             {categories.length === 0 && (
               <div className="menu-items-empty">
-                <div className="menu-items-empty__icon">🍽️</div>
+                <div className="menu-items-empty__icon"><UtensilsCrossed size={36} aria-hidden /></div>
                 <p className="menu-items-empty__text">Erstelle zuerst eine Kategorie, um Artikel hinzuzufügen.</p>
                 <button
                   className="btn-secondary"
@@ -942,7 +955,7 @@ export function MenuPage() {
             {/* Empty state — category has no items */}
             {categories.length > 0 && visibleItems.length === 0 && (
               <div className="menu-items-empty">
-                <div className="menu-items-empty__icon">📋</div>
+                <div className="menu-items-empty__icon"><ClipboardList size={36} aria-hidden /></div>
                 <p className="menu-items-empty__text">
                   {selectedCatId === "all"
                     ? "Noch keine Artikel vorhanden."
@@ -973,13 +986,13 @@ export function MenuPage() {
                           disabled={idx === 0 || reorderingItems}
                           onClick={() => moveItem(idx, -1)}
                           title="Nach oben"
-                        >▲</button>
+                        ><ChevronUp size={12} aria-hidden /></button>
                         <button
                           className="menu-reorder-btn"
                           disabled={idx === visibleItems.length - 1 || reorderingItems}
                           onClick={() => moveItem(idx, 1)}
                           title="Nach unten"
-                        >▼</button>
+                        ><ChevronDown size={12} aria-hidden /></button>
                       </div>
                     )}
 
@@ -988,7 +1001,9 @@ export function MenuPage() {
                       <div className="menu-item-row__name">
                         {item.name}
                         {itemsWithStock.has(item.id) && (
-                          <span className="menu-item-stock-badge" title="Hat Lageranforderungen">🧺</span>
+                          <span className="menu-item-stock-badge" title="Hat Lageranforderungen">
+                            <Package size={13} aria-hidden />
+                          </span>
                         )}
                       </div>
                       {item.description && (
@@ -1019,18 +1034,18 @@ export function MenuPage() {
                         title={item.isLocked ? "Entsperren" : "Sperren"}
                         onClick={() => handleItemToggleLock(item)}
                       >
-                        {item.isLocked ? "🔓" : "🔒"}
+                        {item.isLocked ? <Unlock size={15} aria-hidden /> : <Lock size={15} aria-hidden />}
                       </button>
                       <button
                         className="btn-icon"
                         title="Bearbeiten"
                         onClick={() => { setItemSaveErr(null); setItemEdit(item); }}
-                      >✏️</button>
+                      ><Pencil size={15} aria-hidden /></button>
                       <button
                         className="btn-icon btn-icon--danger"
                         title="Löschen"
                         onClick={() => { setItemDeleteErr(null); setItemDelete(item); }}
-                      >🗑️</button>
+                      ><Trash2 size={15} aria-hidden /></button>
                     </div>
                   </div>
                 ))}

--- a/apps/admin-desktop/src/pages/OrderDisplaysPage.tsx
+++ b/apps/admin-desktop/src/pages/OrderDisplaysPage.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react";
+import { Pencil, Trash2 } from "lucide-react";
 import type { OrderDisplayDto } from "@bstoema/shared-types";
 import { ApiConflictError } from "@bstoema/api-client";
 import { useApiClient } from "../contexts/ApiClientContext";
@@ -393,7 +394,7 @@ export function OrderDisplaysPage() {
                       setEditTarget(display);
                     }}
                   >
-                    ✏️
+                    <Pencil size={15} aria-hidden />
                   </button>
                   <button
                     className="btn-icon btn-icon--danger"
@@ -403,7 +404,7 @@ export function OrderDisplaysPage() {
                       setDeleteTarget(display);
                     }}
                   >
-                    🗑
+                    <Trash2 size={15} aria-hidden />
                   </button>
                 </span>
               </div>

--- a/apps/admin-desktop/src/pages/OrdersPage.tsx
+++ b/apps/admin-desktop/src/pages/OrdersPage.tsx
@@ -7,6 +7,7 @@ import type {
   TableDto,
   UserDto,
 } from "@bstoema/shared-types";
+import { ChevronDown, ChevronRight } from "lucide-react";
 import { useApiClient } from "../contexts/ApiClientContext";
 
 // ---------------------------------------------------------------------------
@@ -372,7 +373,9 @@ export function OrdersPage() {
                     {waiterName.get(order.userId) ?? `#${order.userId}`}
                   </span>
                   <span className="orders-col-count">{totalQty}</span>
-                  <span className="orders-col-toggle">{isExpanded ? "▾" : "▸"}</span>
+                  <span className="orders-col-toggle">
+                  {isExpanded ? <ChevronDown size={14} aria-hidden /> : <ChevronRight size={14} aria-hidden />}
+                </span>
                 </button>
 
                 {isExpanded && (

--- a/apps/admin-desktop/src/pages/PrintersPage.tsx
+++ b/apps/admin-desktop/src/pages/PrintersPage.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react";
+import { Check, Pencil, Printer, Trash2 } from "lucide-react";
 import type { PrinterDto } from "@bstoema/shared-types";
 import { ApiConflictError, ApiPrinterError } from "@bstoema/api-client";
 import { useApiClient } from "../contexts/ApiClientContext";
@@ -415,7 +416,7 @@ export function PrintersPage() {
                       <span className="printers-status printers-status--pending">Druckt…</span>
                     )}
                     {testState?.status === "ok" && (
-                      <span className="printers-status printers-status--ok">✓ OK</span>
+                      <span className="printers-status printers-status--ok"><Check size={13} aria-hidden /> OK</span>
                     )}
                     {testState?.status === "error" && (
                       <span className="printers-status printers-status--error">Fehler</span>
@@ -428,7 +429,7 @@ export function PrintersPage() {
                       disabled={testState?.status === "pending"}
                       onClick={() => handleTestPrint(printer)}
                     >
-                      🖨
+                      <Printer size={15} aria-hidden />
                     </button>
                     <button
                       className="btn-icon"
@@ -438,7 +439,7 @@ export function PrintersPage() {
                         setEditTarget(printer);
                       }}
                     >
-                      ✏️
+                      <Pencil size={15} aria-hidden />
                     </button>
                     <button
                       className="btn-icon btn-icon--danger"
@@ -448,7 +449,7 @@ export function PrintersPage() {
                         setDeleteTarget(printer);
                       }}
                     >
-                      🗑
+                      <Trash2 size={15} aria-hidden />
                     </button>
                   </span>
                 </div>

--- a/apps/admin-desktop/src/pages/StatisticsPage.tsx
+++ b/apps/admin-desktop/src/pages/StatisticsPage.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Download } from "lucide-react";
 import type { MenuItemDto, OrderDto, UserDto } from "@bstoema/shared-types";
 import { useApiClient } from "../contexts/ApiClientContext";
 import { saveTextFile } from "../lib/menu-file";
@@ -435,7 +436,13 @@ export function StatisticsPage() {
           disabled={exporting || orders.length === 0}
           title="Alle Bestelldaten als CSV-Datei exportieren"
         >
-          {exporting ? "Wird exportiert…" : "⭳ CSV exportieren"}
+          {exporting ? (
+            "Wird exportiert…"
+          ) : (
+            <>
+              <Download size={14} aria-hidden /> CSV exportieren
+            </>
+          )}
         </button>
       </div>
     </div>

--- a/apps/admin-desktop/src/pages/StockPage.tsx
+++ b/apps/admin-desktop/src/pages/StockPage.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react";
+import { Minus, Pencil, Plus, Trash2 } from "lucide-react";
 import type {
   MenuItemDto,
   MenuItemStockRequirementDto,
@@ -418,7 +419,7 @@ function RequirementsEditor({
                     title="Zeile entfernen"
                     onClick={() => removeRow(i)}
                   >
-                    🗑
+                    <Trash2 size={15} aria-hidden />
                   </button>
                 </div>
               ))}
@@ -757,11 +758,11 @@ export function StockPage() {
                 <span className="stock-col-actions">
                   <button
                     className="btn-icon"
-                    title="−1"
+                    title="-1"
                     disabled={busy || item.quantity === 0}
                     onClick={() => handleQuickDelta(item, -1)}
                   >
-                    −
+                    <Minus size={15} aria-hidden />
                   </button>
                   <button
                     className="btn-icon"
@@ -769,7 +770,7 @@ export function StockPage() {
                     disabled={busy}
                     onClick={() => handleQuickDelta(item, 1)}
                   >
-                    +
+                    <Plus size={15} aria-hidden />
                   </button>
                   <button
                     className="btn-icon"
@@ -779,7 +780,7 @@ export function StockPage() {
                       setEditTarget(item);
                     }}
                   >
-                    ✏️
+                    <Pencil size={15} aria-hidden />
                   </button>
                 </span>
               </div>

--- a/apps/admin-desktop/src/pages/TablesPage.tsx
+++ b/apps/admin-desktop/src/pages/TablesPage.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react";
+import { Check, ChevronDown, ChevronUp, Lock, Pencil, Unlock } from "lucide-react";
 import { isTauri } from "@tauri-apps/api/core";
 import type { TableDto } from "@bstoema/shared-types";
 import { useApiClient } from "../contexts/ApiClientContext";
@@ -1058,8 +1059,12 @@ function QrExportModal({ tables, onClose }: QrExportModalProps) {
 
         {error && <p className="form-error">{error}</p>}
         {done && !error && (
-          <p className="muted" style={{ color: "#15803d", fontSize: 13 }}>
-            ✓ Export abgeschlossen{savePath ? ` – ${basename(savePath)}` : ""}.
+          <p
+            className="muted"
+            style={{ color: "#15803d", fontSize: 13, display: "flex", alignItems: "center", gap: 4 }}
+          >
+            <Check size={14} aria-hidden />
+            Export abgeschlossen{savePath ? ` – ${basename(savePath)}` : ""}.
           </p>
         )}
 
@@ -1195,7 +1200,7 @@ export function TablesPage() {
     }
   }
 
-  // ── Reorder via ▲/▼ buttons ──────────────────────────────────────────────
+  // ── Reorder via up/down buttons ──────────────────────────────────────────
 
   async function moveTable(idx: number, direction: -1 | 1) {
     const swapIdx = idx + direction;
@@ -1326,7 +1331,7 @@ export function TablesPage() {
                   onClick={() => moveTable(idx, -1)}
                   title="Nach oben"
                   aria-label="Nach oben"
-                >▲</button>
+                ><ChevronUp size={12} aria-hidden /></button>
                 <button
                   type="button"
                   className="menu-reorder-btn"
@@ -1334,7 +1339,7 @@ export function TablesPage() {
                   onClick={() => moveTable(idx, 1)}
                   title="Nach unten"
                   aria-label="Nach unten"
-                >▼</button>
+                ><ChevronDown size={12} aria-hidden /></button>
               </span>
               <span className="tables-col-name">{table.name}</span>
               <span className="tables-col-status">
@@ -1358,7 +1363,7 @@ export function TablesPage() {
                   title={table.isLocked ? "Entsperren" : "Sperren"}
                   onClick={() => handleToggleLock(table)}
                 >
-                  {table.isLocked ? "🔓" : "🔒"}
+                  {table.isLocked ? <Unlock size={15} aria-hidden /> : <Lock size={15} aria-hidden />}
                 </button>
                 <button
                   className="btn-icon"
@@ -1368,7 +1373,7 @@ export function TablesPage() {
                     setEditTarget(table);
                   }}
                 >
-                  ✏️
+                  <Pencil size={15} aria-hidden />
                 </button>
               </span>
             </div>

--- a/apps/admin-desktop/src/pages/UsersPage.tsx
+++ b/apps/admin-desktop/src/pages/UsersPage.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react";
+import { Lock, Trash2, Unlock } from "lucide-react";
 import type { UserDto } from "@bstoema/shared-types";
 import { ApiConflictError } from "@bstoema/api-client";
 import { useApiClient } from "../contexts/ApiClientContext";
@@ -402,7 +403,7 @@ export function UsersPage() {
                   title={user.isLocked ? "Entsperren" : "Sperren"}
                   onClick={() => handleToggleLock(user)}
                 >
-                  {user.isLocked ? "🔓" : "🔒"}
+                  {user.isLocked ? <Unlock size={15} aria-hidden /> : <Lock size={15} aria-hidden />}
                 </button>
                 <button
                   className="btn-icon btn-icon--danger"
@@ -412,7 +413,7 @@ export function UsersPage() {
                     setDeleteTarget(user);
                   }}
                 >
-                  🗑
+                  <Trash2 size={15} aria-hidden />
                 </button>
               </span>
             </div>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,6 +34,9 @@ importers:
       '@tauri-apps/plugin-store':
         specifier: ^2
         version: 2.4.3
+      lucide-react:
+        specifier: ^1.33.0
+        version: 1.33.0(react@19.2.4)
       qrcode:
         specifier: ^1.5.4
         version: 1.5.4
@@ -2224,6 +2227,11 @@ packages:
   lru.min@1.1.4:
     resolution: {integrity: sha512-DqC6n3QQ77zdFpCMASA1a3Jlb64Hv2N2DciFGkO/4L9+q/IpIAuRlKOvCXabtRW6cQf8usbmM6BE/TOPysCdIA==}
     engines: {bun: '>=1.0.0', deno: '>=1.30.0', node: '>=8.0.0'}
+
+  lucide-react@1.33.0:
+    resolution: {integrity: sha512-MTRwMy0ZlL8Ur/vOAiJ9XGHE+kFPC7brq6MxAm0GiGXEBj0qy0jA/pG4N675oSzciO/UCdX8T+5yUQdmDeTLxg==}
+    peerDependencies:
+      react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   mime@3.0.0:
     resolution: {integrity: sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==}
@@ -4792,6 +4800,10 @@ snapshots:
       yallist: 3.1.1
 
   lru.min@1.1.4: {}
+
+  lucide-react@1.33.0(react@19.2.4):
+    dependencies:
+      react: 19.2.4
 
   mime@3.0.0: {}
 


### PR DESCRIPTION
Closes #165

## What

Swaps every emoji/dingbat used as an icon in `admin-desktop` for a [lucide-react](https://lucide.dev) SVG icon.

| Was | Now |
|---|---|
| 🔒 / 🔓 | `Lock` / `Unlock` |
| ✏️ | `Pencil` |
| 🗑️ / 🗑 | `Trash2` |
| 🖨 | `Printer` |
| 🧺 | `Package` |
| 🍽️ | `UtensilsCrossed` |
| 📋 | `ClipboardList` |
| ⭳ / ⭱ | `Download` / `Upload` |
| ▲ / ▼ | `ChevronUp` / `ChevronDown` |
| ▾ / ▸ | `ChevronDown` / `ChevronRight` |
| ✓ | `Check` |
| − / + | `Minus` / `Plus` |

Icons inherit `currentColor` and are sized per call site, so they render identically everywhere instead of depending on the host emoji font.

## CSS

Containers that sized their glyph via `font-size` now use flex + gap:
`.menu-items-empty__icon`, `.menu-item-stock-badge`, `.orders-col-toggle`, `.config-saved`, `.printers-status`. `.btn-primary` / `.btn-secondary` gained `gap: 6px` so icon+label buttons space correctly.

## Verification

- `tsc` + `vite build` clean; existing e2e suite passes.
- A temporary Playwright run (seeded event, menu, tables, printers, order displays, users, stock, orders, statistics, logs, config) walked every admin page and asserted no emoji/dingbat codepoint remains in the rendered DOM — including hover-revealed row actions, the menu empty state, and the expanded order row. Screenshots reviewed; the throwaway spec is not committed.
- Repo-wide scan of `apps/admin-desktop` finds no remaining emoji.

Pre-existing, untouched: `ConfigPage`'s Gespeichert marker never paints because `patchOne()` updates `serverValue`, which resets the row's save state to idle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)