### PR TITLE
fix(admin-desktop): icons follow the dark-mode text colour

### DIFF
--- a/apps/admin-desktop/src/App.css
+++ b/apps/admin-desktop/src/App.css
@@ -869,7 +869,10 @@ html, body, #root {
 .btn-danger:hover:not(:disabled) { background: #dc2626; }
 .btn-danger:disabled { opacity: 0.55; cursor: not-allowed; }
 
-/* Small icon-only action buttons in table rows */
+/* Small icon-only action buttons in table rows.
+   `color` must be set explicitly: the UA stylesheet gives buttons the system
+   `buttontext` colour, which stays black in dark mode — and the lucide SVGs
+   inside are drawn with `currentColor`. */
 .btn-icon {
   display: inline-flex;
   align-items: center;
@@ -877,6 +880,7 @@ html, body, #root {
   width: 30px;
   height: 30px;
   background: transparent;
+  color: var(--color-text);
   border: 1px solid transparent;
   border-radius: var(--radius-sm);
   font-size: 14px;
@@ -885,7 +889,10 @@ html, body, #root {
   line-height: 1;
   flex-shrink: 0;
 }
-.btn-icon:hover { background: #f3f4f6; border-color: var(--color-border); }
+/* An explicit `color` overrides the UA's greyed-out disabled text, so restore
+   the disabled affordance here. */
+.btn-icon:disabled { opacity: 0.35; cursor: default; }
+.btn-icon:hover:not(:disabled) { background: #f3f4f6; border-color: var(--color-border); }
 .btn-icon--danger:hover { background: #fef2f2; border-color: #fca5a5; }
 .btn-icon--unlock:hover { background: #f0fdf4; border-color: #86efac; }
 
@@ -1017,7 +1024,7 @@ html, body, #root {
   .badge-locked  { background: #450a0a; color: #fca5a5; }
   .badge-unlocked { background: #14532d; color: #86efac; }
   .cat-delete-error { background: #450a0a; border-color: #7f1d1d; color: #fca5a5; }
-  .btn-icon:hover { background: #374151; border-color: #4b5563; }
+  .btn-icon:hover:not(:disabled) { background: #374151; border-color: #4b5563; }
   .btn-icon--danger:hover { background: #450a0a; border-color: #991b1b; }
   .btn-icon--unlock:hover { background: #14532d; border-color: #166534; }
 }


### PR DESCRIPTION
Follow-up to #165 / #168.

## Problem

`.btn-icon` never set a `color`, so buttons fell back to the UA stylesheet's system `buttontext` — **pure black in both colour schemes**. That was invisible while the icons were emoji (colour glyphs draw themselves), but lucide SVGs are stroked with `currentColor`, so every row action (lock/unlock, edit, delete, printer, ±) rendered black on the dark surface.

Confirmed by measuring computed style in a dark-mode browser: those SVGs reported `rgb(0, 0, 0)`, and `.btn-icon` was the *only* offending class — every other icon container already sets a colour.

## Fix

- `.btn-icon { color: var(--color-text) }` — `#f9fafb` in dark, `#111827` in light, so it follows the scheme.
- An explicit author `color` also cancels the UA's greyed-out disabled text, so `.btn-icon:disabled { opacity: 0.35 }` restores the disabled affordance (stock `-1` at quantity 0, printer test-print while pending), and the hover backgrounds are guarded with `:not(:disabled)`.

## Verification

A temporary Playwright run walked all 11 admin pages plus hover-revealed row actions, reading the computed `color` of every visible SVG and asserting its relative luminance is on the correct side for the active scheme (titlebar controls excluded — that bar stays dark purple in both schemes, so its icons are intentionally white).

- **dark**: passes; screenshots show white icons throughout.
- **light**: passes; visually identical to before this change.
- **negative control**: reverting just the `color` line makes the dark run fail with 12 × `.btn-icon` at `rgb(0, 0, 0)` — so the check is not vacuous.
- Disabled `-1` measured at `opacity: 0.35` in both schemes.

`tsc` + `vite build` clean; existing e2e suite passes. The throwaway spec is not committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)