### PR TITLE
chore(waiter-web): remaining sum on the payment screen, no more line deletion

### DIFF
--- a/apps/waiter-web/src/contexts/CartContext.tsx
+++ b/apps/waiter-web/src/contexts/CartContext.tsx
@@ -48,6 +48,10 @@ interface CartContextValue {
   count: number
   /** Grand total in currency units. */
   total: number
+  /** Billable units that have not been paid yet (count minus every line's paidQty). */
+  openCount: number
+  /** What is still owed in currency units — the grand total minus everything paid. */
+  openTotal: number
 
   // ── Cart lifecycle ──────────────────────────────────────────────────────
   /**
@@ -259,14 +263,19 @@ export function CartProvider({ children }: { children: ReactNode }) {
 
   // ── Derived values ──────────────────────────────────────────────────────
 
-  const { count, total } = useMemo(() => {
-    let c = 0, t = 0
+  const { count, total, openCount, openTotal } = useMemo(() => {
+    let c = 0, t = 0, oc = 0, ot = 0
     for (const line of Object.values(cart.lines)) {
       const units = lineUnits(line)
+      // paidQty is capped at lineUnits() in payItems(), but clamp anyway so a
+      // stale line can never produce a negative open amount.
+      const open = Math.max(0, units - line.paidQty)
       c += units
       t += units * line.item.price
+      oc += open
+      ot += open * line.item.price
     }
-    return { count: c, total: t }
+    return { count: c, total: t, openCount: oc, openTotal: ot }
   }, [cart.lines])
 
   const value: CartContextValue = {
@@ -274,6 +283,8 @@ export function CartProvider({ children }: { children: ReactNode }) {
     lines: cart.lines,
     count,
     total,
+    openCount,
+    openTotal,
     initForTable,
     clearCart,
     addItem,

--- a/apps/waiter-web/src/index.css
+++ b/apps/waiter-web/src/index.css
@@ -900,7 +900,7 @@ body {
   gap: 10px;
 }
 
-/* Top row: name + line total on the left, stepper + × on the right */
+/* Top row: name + line total on the left, sub-bill stepper on the right */
 .order-row__top {
   display: flex;
   align-items: flex-start;
@@ -936,38 +936,6 @@ body {
   display: flex;
   align-items: center;
   gap: 8px;
-}
-
-/* ×-remove button */
-.order-row__remove {
-  width: 36px;
-  height: 36px;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  border: 1px solid var(--color-border);
-  border-radius: 999px;
-  background: var(--color-bg);
-  color: var(--color-danger);
-  font: inherit;
-  font-size: 20px;
-  line-height: 1;
-  cursor: pointer;
-  -webkit-tap-highlight-color: transparent;
-  touch-action: manipulation;
-  transition: border-color 0.12s, background 0.12s;
-}
-
-.order-row__remove:disabled {
-  opacity: 0.4;
-  cursor: not-allowed;
-}
-
-@media (hover: hover) {
-  .order-row__remove:not(:disabled):hover {
-    border-color: var(--color-danger);
-    background: color-mix(in srgb, var(--color-danger) 8%, var(--color-bg));
-  }
 }
 
 /* Unit-price hint */
@@ -1622,19 +1590,6 @@ body {
   align-items: center;
   gap: 8px;
   flex-shrink: 0;
-}
-
-.order-row__remove {
-  background: transparent;
-  border: 1px solid var(--color-border);
-  border-radius: 8px;
-  padding: 6px 10px;
-  font-size: 18px;
-  line-height: 1;
-  color: var(--color-text-muted, #888);
-  cursor: pointer;
-  -webkit-tap-highlight-color: transparent;
-  touch-action: manipulation;
 }
 
 .order-row__price-hint {

--- a/apps/waiter-web/src/pages/OrderPage.tsx
+++ b/apps/waiter-web/src/pages/OrderPage.tsx
@@ -33,9 +33,8 @@ export function OrderPage() {
 
   const {
     lines,
-    count,
-    total,
-    removeItem,
+    openCount,
+    openTotal,
     clearCart,
     payItems,
   } = useCart()
@@ -141,7 +140,6 @@ export function OrderPage() {
                 disabled={false}
                 subBillQty={subQty}
                 openQty={openQty}
-                onRemove={() => removeItem(line.item.id)}
                 onSetSubBillQty={(qty) => setSubBillQty(line.item.id, qty)}
               />
             )
@@ -174,12 +172,13 @@ export function OrderPage() {
         </div>
       )}
 
-      {/* Summary */}
-      <div className="order-summary" aria-label="Bestellzusammenfassung">
+      {/* Summary — what is still owed, not the full bill: already-paid units
+          (full or via Teilrechnung) are excluded from both figures. */}
+      <div className="order-summary" aria-label="Offener Betrag">
         <div className="order-summary__breakdown">
-          <span className="order-summary__sub">{count} Artikel</span>
+          <span className="order-summary__sub">{openCount} Artikel offen</span>
         </div>
-        <span className="order-summary__total">{formatPrice(total)}</span>
+        <span className="order-summary__total">{formatPrice(openTotal)}</span>
       </div>
 
       {/* Action row — the order is already placed; this only ends the session. */}
@@ -207,7 +206,6 @@ interface CartItemRowProps {
   errorKind?: 'locked' | 'notFound'
   subBillQty: number
   openQty: number
-  onRemove(): void
   onSetSubBillQty(qty: number): void
 }
 
@@ -217,7 +215,6 @@ function CartItemRow({
   errorKind,
   subBillQty,
   openQty,
-  onRemove,
   onSetSubBillQty,
 }: CartItemRowProps) {
   const { item, qty, specialRequests, paidQty } = line
@@ -239,9 +236,11 @@ function CartItemRow({
         </div>
 
         <div className="order-row__controls">
-          {/* Split-bill (Teilrechnung) stepper — takes the place the quantity
-              stepper used to occupy. Waiters can no longer edit quantities here;
-              they only choose how many units go onto the sub-bill. */}
+          {/* Split-bill (Teilrechnung) stepper — the only control on this row.
+              The order is already placed and printed by the time the waiter gets
+              here, so quantities can't be edited and lines can't be removed
+              (issue #166); the stepper only chooses how many units go onto the
+              sub-bill. */}
           {openQty > 0 && (
             <div className="subbill-stepper" role="group" aria-label={`Zur Teilrechnung: ${item.name}`}>
               <button
@@ -267,25 +266,16 @@ function CartItemRow({
               </button>
             </div>
           )}
-
-          <button
-            type="button"
-            className="order-row__remove"
-            onClick={onRemove}
-            disabled={disabled}
-            aria-label={`${item.name} entfernen`}
-            title="Entfernen"
-          >
-            &#215;
-          </button>
         </div>
       </div>
 
       {errorKind && (
         <p className="order-row__item-error" role="alert">
+          {/* No "bitte entfernen" hint any more — this screen can no longer
+              delete lines (issue #166). */}
           {errorKind === 'locked'
-            ? 'Dieser Artikel ist nicht mehr verfügbar — bitte entfernen.'
-            : 'Artikel nicht gefunden — bitte entfernen und Menü aktualisieren.'}
+            ? 'Dieser Artikel ist nicht mehr verfügbar.'
+            : 'Artikel nicht gefunden — bitte Menü aktualisieren.'}
         </p>
       )}
 


### PR DESCRIPTION
Closes #166

## Remaining sum instead of the full sum

The payment-screen footer summed every line in the cart, so it kept showing the whole bill after a Teilrechnung had been settled — pay 1 of 4 units and it still read `12,00 €`.

`CartContext` now derives `openCount` / `openTotal` alongside `count` / `total`:

```ts
const open = Math.max(0, lineUnits(line) - line.paidQty)
oc += open
ot += open * line.item.price
```

`OrderPage` uses those. **The ordering screen (`MenuPage`) keeps `count` / `total`** — nothing is paid yet there, so the full sum is the right number.

The label changed from `3 Artikel` to `3 Artikel offen`. Leaving a full item count next to a remaining amount would have read as a bug, so both figures in that footer now mean the same thing.

## No more deletion in the payment screen

Removed the per-row `×` button, its `onRemove` prop, and the dead `.order-row__remove` CSS (two blocks). By the time this screen opens the order is already placed and its bons printed, so deleting a line here only desynced the waiter's display from what the kitchen received. The sub-bill stepper is now the only control on the row.

`CartContext.removeItem()` is left in place — it's part of the cart API, just no longer called from this screen.

The `errorKind` copy told the waiter to remove the line, which is no longer possible, so that wording is fixed too. (That branch is dead code today — `errorKind` is never passed — but it would have shipped a contradictory instruction.)

## Verification

A temporary Playwright spec drove the real waiter flow end to end — login, table, 3× Bier plus a Sonderwunsch (so `lineUnits` = qty + SR qty is exercised), order & print, then the payment screen:

| step | expected | asserted |
|---|---|---|
| ordering screen, nothing paid | `12,00 €` full total | yes |
| payment screen, nothing paid | `12,00 €` / `4 Artikel offen` | yes |
| pay 1 unit via Teilrechnung | `9,00 €` / `3 Artikel offen`, badges `1 bezahlt` / `3 offen` | yes |
| pay the remaining 3 | `0,00 €` / `0 Artikel offen`, `Bezahlt` badge, stepper gone | yes |
| remove controls | `.order-row__remove` count 0, no remove button, no stray `×` button | yes |

**Negative control:** putting `total` back in the footer makes the post-payment assertion fail with `9,00 €` → `12,00 €` — i.e. it reproduces exactly the bug in the issue, so the check is not vacuous.

`tsc -b` + `vite build` clean; the existing e2e suite passes. `pnpm --filter waiter-web lint` reports the same 7 pre-existing errors as `main` (verified by stashing) — this change adds none. The throwaway spec is not committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
