### PR TITLE
feat(waiter-web): order check screen with a bon preview

### DIFF
--- a/apps/waiter-web/README.md
+++ b/apps/waiter-web/README.md
@@ -42,7 +42,16 @@ pnpm --filter waiter-web lint
 
 ## Layout
 
-- `src/pages/*` — Tables, Menu, Order, Orders, Login screens
+- `src/pages/*` — Tables, Menu, CheckOrder, Order, Orders, Login screens
 - `src/contexts/*` — cart state (`CartContext`) and API client wiring
 - `src/components/*` — shared UI (layout shell, error boundary)
+- `src/lib/*` — order submission (`order-submit`) and the bon preview
+  (`bon-preview`, which mirrors the API's bon rendering)
 - `e2e/*` — Playwright specs
+
+## Ordering flow
+
+`/tables` → `/tables/:id/menu` (build the cart) → `/tables/:id/check` (preview the
+bon, go back or confirm) → the order is created and printed → `/tables/:id/order`
+(settle the bill). The cart is in-memory only, so a reload drops it and the check
+screen bounces back to the menu.

--- a/apps/waiter-web/src/App.tsx
+++ b/apps/waiter-web/src/App.tsx
@@ -19,6 +19,7 @@ import { Layout } from './components/Layout'
 import { LoginPage } from './pages/LoginPage'
 import { TablesPage } from './pages/TablesPage'
 import { MenuPage } from './pages/MenuPage'
+import { CheckOrderPage } from './pages/CheckOrderPage'
 import { OrderPage } from './pages/OrderPage'
 import { OrdersPage } from './pages/OrdersPage'
 
@@ -66,6 +67,7 @@ function AppRoutes() {
       <Route element={<ProtectedLayout />}>
         <Route path="/tables" element={<TablesPage />} />
         <Route path="/tables/:tableId/menu" element={<MenuPage />} />
+        <Route path="/tables/:tableId/check" element={<CheckOrderPage />} />
         <Route path="/tables/:tableId/order" element={<OrderPage />} />
         <Route path="/orders" element={<OrdersPage />} />
       </Route>

--- a/apps/waiter-web/src/index.css
+++ b/apps/waiter-web/src/index.css
@@ -1145,6 +1145,118 @@ body {
   box-shadow: 0 4px 14px rgba(0, 0, 0, 0.22);
 }
 
+/* ─── Check-order page (bon preview before printing) ─────────── */
+.check-page {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  /* Room to scroll the summary clear of the fixed action row — this page ends
+     in a summary card rather than a list, so it needs more than .order-page. */
+  padding-bottom: 150px;
+}
+
+.check-page__header {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.check-page__title {
+  margin: 0;
+  font-size: 28px;
+  font-weight: 800;
+  line-height: 1.1;
+  letter-spacing: -0.02em;
+  color: var(--color-text);
+}
+
+.check-page__subtitle {
+  margin: 0;
+  font-size: 14px;
+  color: var(--color-text-muted);
+}
+
+.bon-preview {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+/* Deliberately paper-like: monospace, narrow, centred — so the waiter reads it
+   as "this is the slip the kitchen gets", not as another app screen. */
+.bon-preview__paper {
+  align-self: center;
+  width: 100%;
+  max-width: 340px;
+  padding: 18px 16px;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 13px;
+  line-height: 1.45;
+  color: var(--color-text);
+}
+
+.bon-preview__table {
+  text-align: center;
+  font-size: 22px;
+  font-weight: 700;
+  line-height: 1.2;
+  word-break: break-word;
+}
+
+.bon-preview__rule {
+  margin: 10px 0;
+  border-top: 1px dashed var(--color-border);
+}
+
+.bon-preview__meta {
+  color: var(--color-text-muted);
+}
+
+.bon-preview__items {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.bon-preview__item {
+  display: flex;
+  flex-direction: column;
+}
+
+/* The printer renders item lines in quad-area text, so they dominate the slip. */
+.bon-preview__item-line {
+  font-size: 17px;
+  font-weight: 700;
+  word-break: break-word;
+}
+
+.bon-preview__item-note {
+  padding-left: 10px;
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--color-text);
+  word-break: break-word;
+}
+
+.bon-preview__end {
+  text-align: center;
+  color: var(--color-text-muted);
+}
+
+.bon-preview__hint {
+  margin: 0;
+  font-size: 12px;
+  line-height: 1.4;
+  color: var(--color-text-muted);
+  text-align: center;
+}
+
 /* ── Success toast ───────────────────────────────────────────── */
 .order-toast {
   position: fixed;

--- a/apps/waiter-web/src/lib/bon-preview.ts
+++ b/apps/waiter-web/src/lib/bon-preview.ts
@@ -1,0 +1,86 @@
+import { lineUnits } from '../contexts/CartContext'
+import type { CartLine } from '../contexts/CartContext'
+import { toOrderItems } from './order-submit'
+
+// ---------------------------------------------------------------------------
+// Bon preview
+// ---------------------------------------------------------------------------
+//
+// Reproduces the body of the kitchen bon *before* the order is sent, so the
+// waiter can check it on the confirmation screen (issue #167).
+//
+// This deliberately runs the same encode → decode round-trip the real bon goes
+// through — toOrderItems() joins a line's special requests into one "[Nx ]text"
+// string separated by "; ", and the API splits that string apart again in
+// `parseSpecialRequests` (apps/api/src/domain/printer-store.ts) before laying
+// out the lines in `formatOrderBon`. Previewing the decoded form rather than the
+// raw cart means a note that survives the round-trip badly (one containing "; ",
+// say) looks wrong here too — which is the point: this shows what will actually
+// print, not what we wish would print.
+//
+// Keep in sync with `formatOrderBon` / `parseSpecialRequests` in
+// apps/api/src/domain/printer-store.ts.
+
+export interface BonPreviewLine {
+  /** Units on this line. */
+  qty: number
+  /** Menu item name. */
+  name: string
+  /** The special-request note, when this line is a noted unit. */
+  note?: string
+}
+
+/** Mirror of `parseSpecialRequests` in the API's printer-store. */
+function parseSpecialRequests(raw: string): Array<{ qty: number; text: string }> {
+  if (!raw) return []
+  const requests: Array<{ qty: number; text: string }> = []
+  for (const part of raw.split('; ')) {
+    const trimmed = part.trim()
+    if (!trimmed) continue
+    const match = /^(\d+)x (.+)$/.exec(trimmed)
+    if (match) {
+      requests.push({ qty: Number(match[1]), text: match[2] })
+    } else {
+      requests.push({ qty: 1, text: trimmed })
+    }
+  }
+  return requests
+}
+
+/**
+ * The item lines the bon will carry, in print order.
+ *
+ * Plain (un-noted) units print first as a single `Nx Item` line, then one line
+ * per distinct special request — so the kitchen sees exactly how many of the
+ * item are modified.
+ */
+export function buildBonItemLines(lines: CartLine[]): BonPreviewLine[] {
+  const orderItems = toOrderItems(lines)
+  const byId = new Map(lines.map((line) => [line.item.id, line]))
+  const out: BonPreviewLine[] = []
+
+  for (const orderItem of orderItems) {
+    const line = byId.get(orderItem.menuItemId)
+    if (!line) continue
+
+    const requests = parseSpecialRequests(orderItem.specialRequests ?? '')
+    const specialUnits = requests.reduce((sum, r) => sum + r.qty, 0)
+    const plainQty = lineUnits(line) - specialUnits
+
+    if (plainQty > 0) {
+      out.push({ qty: plainQty, name: line.item.name })
+    }
+    for (const request of requests) {
+      out.push({ qty: request.qty, name: line.item.name, note: request.text })
+    }
+  }
+
+  return out
+}
+
+/** `HH:MM` in the device's local time — the same shape the bon prints. */
+export function formatBonTime(date: Date): string {
+  const hh = String(date.getHours()).padStart(2, '0')
+  const mm = String(date.getMinutes()).padStart(2, '0')
+  return `${hh}:${mm}`
+}

--- a/apps/waiter-web/src/pages/CheckOrderPage.tsx
+++ b/apps/waiter-web/src/pages/CheckOrderPage.tsx
@@ -1,0 +1,224 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useLocation, useNavigate, useParams } from 'react-router-dom'
+import { ApiNotFoundError } from '@bstoema/api-client'
+import { useAuth } from '@bstoema/auth-context'
+import { useApiClient } from '../hooks/useApiClient'
+import { useCart } from '../contexts/CartContext'
+import { PrintResultModal } from '../components/PrintResultModal'
+import { buildBonItemLines, formatBonTime } from '../lib/bon-preview'
+import {
+  errorCodeToMessage,
+  runOrderPrint,
+  toOrderItems,
+} from '../lib/order-submit'
+import type { PrintResultModalState } from '../lib/order-submit'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const eurFormatter = new Intl.NumberFormat('de-DE', {
+  style: 'currency',
+  currency: 'EUR',
+})
+
+function formatPrice(value: number): string {
+  return eurFormatter.format(value)
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+//
+// Confirmation screen between the menu and the printer (issue #167). Nothing has
+// been sent yet when this renders: the waiter sees a preview of the bon the
+// kitchen will receive and either goes back to the menu to fix the order, or
+// confirms — which is the point where the order is created and its bons printed.
+//
+// Submitting lives here rather than on the menu so there is exactly one place in
+// the app that turns a cart into an order.
+
+export function CheckOrderPage() {
+  const { tableId } = useParams<{ tableId: string }>()
+  const client = useApiClient()
+  const navigate = useNavigate()
+  const location = useLocation()
+  const { user } = useAuth()
+
+  const { lines, count, total } = useCart()
+
+  const tableName =
+    (location.state as { tableName?: string } | null)?.tableName ?? null
+
+  const [submitting, setSubmitting] = useState(false)
+  const [submitError, setSubmitError] = useState<string | null>(null)
+  const [printResult, setPrintResult] = useState<PrintResultModalState | null>(null)
+
+  const liveRef = useRef(true)
+  useEffect(() => {
+    liveRef.current = true
+    return () => {
+      liveRef.current = false
+    }
+  }, [])
+
+  const lineList = useMemo(() => Object.values(lines), [lines])
+  const bonLines = useMemo(() => buildBonItemLines(lineList), [lineList])
+
+  // The bon prints the time the *order* is created; until the waiter confirms,
+  // showing the current clock is the closest honest approximation.
+  const previewTime = formatBonTime(new Date())
+
+  const menuPath = `/tables/${tableId}/menu`
+
+  const handleBack = useCallback(() => {
+    navigate(menuPath, { state: { tableName } })
+  }, [navigate, menuPath, tableName])
+
+  // Nothing to confirm (direct URL load, or a refresh that dropped the
+  // in-memory cart) — send the waiter back to the menu.
+  const isEmpty = bonLines.length === 0
+  useEffect(() => {
+    if (isEmpty) navigate(menuPath, { replace: true, state: { tableName } })
+  }, [isEmpty, navigate, menuPath, tableName])
+
+  // ── Confirm & print ────────────────────────────────────────────────────
+  //
+  // The cart is intentionally *not* cleared: the order items carry over to the
+  // payment screen so the bill can be settled there (issue #131).
+
+  const handleConfirm = useCallback(async () => {
+    const tableIdNum = Number(tableId)
+    if (!Number.isFinite(tableIdNum) || tableIdNum <= 0) return
+    if (lineList.length === 0) return
+
+    setSubmitting(true)
+    setSubmitError(null)
+
+    try {
+      const order = await client.orders.create({
+        tableId: tableIdNum,
+        items: toOrderItems(lineList),
+      })
+
+      const result = await runOrderPrint(() => client.orders.print(order.id))
+      if (!liveRef.current) return
+      setPrintResult(result)
+      setSubmitting(false)
+    } catch (err) {
+      if (!liveRef.current) return
+      // Table vanished mid-flow — bail back to the table list.
+      if (err instanceof ApiNotFoundError && err.code === 'TABLE_NOT_FOUND') {
+        setSubmitError(errorCodeToMessage(err))
+        setSubmitting(false)
+        setTimeout(() => navigate('/tables', { replace: true }), 1500)
+        return
+      }
+      setSubmitError(errorCodeToMessage(err))
+      setSubmitting(false)
+    }
+  }, [client, lineList, tableId, navigate])
+
+  // Order placed and bons printed — move on to the payment screen.
+  const handleCloseResult = useCallback(() => {
+    setPrintResult(null)
+    navigate(`/tables/${tableId}/order`, { state: { tableName } })
+  }, [navigate, tableId, tableName])
+
+  if (isEmpty) return null
+
+  const heading = tableName ?? `Tisch ${tableId}`
+
+  return (
+    <div className="page check-page">
+      {printResult && (
+        <PrintResultModal state={printResult} onClose={handleCloseResult} />
+      )}
+
+      <div className="check-page__header">
+        <button
+          type="button"
+          className="back-button"
+          onClick={handleBack}
+          disabled={submitting}
+          aria-label="Zurueck zur Speisekarte"
+        >
+          <span className="back-button__icon" aria-hidden="true">&#8249;</span>
+          <span>Speisekarte</span>
+        </button>
+        <h1 className="check-page__title">Bestellung prüfen</h1>
+        <p className="check-page__subtitle">
+          So wird der Bon in der Küche gedruckt.
+        </p>
+      </div>
+
+      {/* Bon preview — mirrors the layout the thermal printer produces. */}
+      <div className="bon-preview" role="region" aria-label="Vorschau des Bons">
+        <div className="bon-preview__paper">
+          <div className="bon-preview__table">{heading}</div>
+          <div className="bon-preview__rule" aria-hidden="true" />
+
+          <div className="bon-preview__meta">
+            <div>Bestellung #—</div>
+            <div>Kellner: {user?.username ?? '?'}</div>
+            <div>Zeit: {previewTime}</div>
+          </div>
+          <div className="bon-preview__rule" aria-hidden="true" />
+
+          <ul className="bon-preview__items">
+            {bonLines.map((bonLine, idx) => (
+              <li key={idx} className="bon-preview__item">
+                <span className="bon-preview__item-line">
+                  {bonLine.qty}x {bonLine.name}
+                </span>
+                {bonLine.note && (
+                  <span className="bon-preview__item-note">*{bonLine.note}</span>
+                )}
+              </li>
+            ))}
+          </ul>
+
+          <div className="bon-preview__rule" aria-hidden="true" />
+          <div className="bon-preview__end">Ende Bon</div>
+        </div>
+        <p className="bon-preview__hint">
+          Bestellnummer und Uhrzeit werden beim Drucken gesetzt. Artikel
+          verschiedener Kategorien können auf mehreren Druckern landen.
+        </p>
+      </div>
+
+      {/* What the guest pays — the bon itself carries no prices. */}
+      <div className="order-summary" aria-label="Bestellzusammenfassung">
+        <div className="order-summary__breakdown">
+          <span className="order-summary__sub">{count} Artikel</span>
+        </div>
+        <span className="order-summary__total">{formatPrice(total)}</span>
+      </div>
+
+      {submitError && (
+        <p className="error-message order-submit-error" role="alert">
+          {submitError}
+        </p>
+      )}
+
+      <div className="order-actions">
+        <button
+          type="button"
+          className="btn-split"
+          onClick={handleBack}
+          disabled={submitting}
+        >
+          Zurück
+        </button>
+        <button
+          type="button"
+          className="btn-primary btn-place-order"
+          onClick={handleConfirm}
+          disabled={submitting}
+        >
+          {submitting ? 'Wird gedruckt…' : 'Bestellen & drucken'}
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/apps/waiter-web/src/pages/MenuPage.tsx
+++ b/apps/waiter-web/src/pages/MenuPage.tsx
@@ -1,17 +1,9 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { useLocation, useNavigate, useParams } from 'react-router-dom'
-import { ApiNotFoundError } from '@bstoema/api-client'
 import type { MenuCategoryDto, MenuItemDto } from '@bstoema/shared-types'
 import { useApiClient } from '../hooks/useApiClient'
 import { useCart } from '../contexts/CartContext'
 import type { CartLine } from '../contexts/CartContext'
-import { PrintResultModal } from '../components/PrintResultModal'
-import {
-  errorCodeToMessage,
-  runOrderPrint,
-  toOrderItems,
-} from '../lib/order-submit'
-import type { PrintResultModalState } from '../lib/order-submit'
 
 // ---------------------------------------------------------------------------
 // Types & helpers
@@ -189,69 +181,23 @@ export function MenuPage() {
     [decrementItem],
   )
 
-  // ── Confirm & print ────────────────────────────────────────────────────
+  // ── Review step ────────────────────────────────────────────────────────
   //
-  // The bon is printed here, right after the waiter confirms the selection, so
-  // the kitchen can start immediately. Payment happens afterwards on the cart
-  // screen (issue #131) — so the cart is intentionally *not* cleared: the order
-  // items carry over so they can be settled. On success we show the print
-  // result, then hand off to the cart/payment page.
-
-  const [submitting, setSubmitting] = useState(false)
-  const [submitError, setSubmitError] = useState<string | null>(null)
-  const [printResult, setPrintResult] = useState<PrintResultModalState | null>(null)
+  // Nothing is sent from here: the CTA hands off to the check screen, where the
+  // waiter sees a preview of the bon and either comes back or confirms. Creating
+  // and printing the order lives there (issue #167).
 
   const hasOrderableItems =
     count > 0 || Object.values(lines).some((l) => l.specialRequests.length > 0)
 
-  const handleConfirm = useCallback(async () => {
-    const tableIdNum = Number(tableId)
-    if (!Number.isFinite(tableIdNum) || tableIdNum <= 0) return
-    const lineList = Object.values(lines)
-    if (!lineList.some((l) => l.qty > 0 || l.specialRequests.length > 0)) return
-
-    setSubmitting(true)
-    setSubmitError(null)
-
-    try {
-      const order = await client.orders.create({
-        tableId: tableIdNum,
-        items: toOrderItems(lineList),
-      })
-
-      const result = await runOrderPrint(() => client.orders.print(order.id))
-      if (!liveRef.current) return
-      setPrintResult(result)
-      setSubmitting(false)
-    } catch (err) {
-      if (!liveRef.current) return
-      // Table vanished mid-flow — bail back to the table list.
-      if (err instanceof ApiNotFoundError && err.code === 'TABLE_NOT_FOUND') {
-        setSubmitError(errorCodeToMessage(err))
-        setSubmitting(false)
-        setTimeout(() => navigate('/tables', { replace: true }), 1500)
-        return
-      }
-      setSubmitError(errorCodeToMessage(err))
-      setSubmitting(false)
-    }
-  }, [client, lines, tableId, navigate])
-
-  // Order is placed and bons printed — move on to the payment screen. The cart
-  // is preserved so the waiter can settle the bill there.
-  const handleCloseResult = useCallback(() => {
-    setPrintResult(null)
-    navigate(`/tables/${tableId}/order`, { state: { tableName } })
+  const handleReview = useCallback(() => {
+    navigate(`/tables/${tableId}/check`, { state: { tableName } })
   }, [navigate, tableId, tableName])
 
   // ── Render ─────────────────────────────────────────────────────────────
 
   return (
     <div className="page menu-page">
-      {printResult && (
-        <PrintResultModal state={printResult} onClose={handleCloseResult} />
-      )}
-
       <div className="menu-page__header">
         <button
           type="button"
@@ -298,18 +244,11 @@ export function MenuPage() {
         }}
       />
 
-      {submitError && (
-        <p className="error-message order-submit-error" role="alert">
-          {submitError}
-        </p>
-      )}
-
       {hasOrderableItems && (
         <button
           type="button"
           className="next-cta"
-          onClick={handleConfirm}
-          disabled={submitting}
+          onClick={handleReview}
         >
           <span className="next-cta__info">
             <span className="next-cta__count" aria-label="Anzahl Artikel">
@@ -323,12 +262,10 @@ export function MenuPage() {
             </span>
           </span>
           <span className="next-cta__action">
-            {submitting ? 'Wird gedruckt…' : 'Bestellen & drucken'}
-            {!submitting && (
-              <span className="next-cta__arrow" aria-hidden="true">
-                →
-              </span>
-            )}
+            Bestellung prüfen
+            <span className="next-cta__arrow" aria-hidden="true">
+              →
+            </span>
           </span>
         </button>
       )}


### PR DESCRIPTION
Closes #167

## What

A confirmation step now sits between the menu and the printer. The menu CTA used to submit and print immediately — a mistyped quantity or a wrong special request was only noticeable once the bon was already out of the kitchen printer.

New route `/tables/:tableId/check`:

```
/tables → /tables/:id/menu → /tables/:id/check → (create + print) → /tables/:id/order
                                   ↑ back ↓
```

The screen renders a preview of the bon and offers **Zurück** (back to the menu, cart intact) and **Bestellen & drucken**. Creating and printing moved out of `MenuPage` into `CheckOrderPage`, so there is now exactly one place in the app that turns a cart into an order.

## The preview

`src/lib/bon-preview.ts` reproduces the bon body by running the same encode → decode round-trip the real bon goes through:

- `toOrderItems()` joins a line's special requests into one `[Nx ]text` string separated by `"; "`,
- the API splits that apart again in `parseSpecialRequests` and lays out the lines in `formatOrderBon` (`apps/api/src/domain/printer-store.ts`).

Previewing the *decoded* form rather than the raw cart means a note that survives that trip badly (one containing `"; "`, say) looks wrong here too — which is the point: this shows what will actually print, not what we wish would print. The module carries a keep-in-sync note pointing at the API function it mirrors.

The paper is styled monospace and narrow so it reads as "the slip the kitchen gets", not as another app screen. `Bestellung #—` and the clock are labelled as set-at-print-time, and a hint notes that items from different categories can land on several printers — waiters can't read `/printers` (admin-only), so the preview deliberately shows one combined slip rather than guessing the per-printer split.

## Verification

A temporary Playwright spec drove the real waiter flow with 2× Bier + 1× Wasser + a "ohne Schaum" note on one Bier:

| check | result |
|---|---|
| menu CTA now reads `Bestellung prüfen` | yes |
| no order exists before review | yes |
| preview lines | `["2x Bier", "1x Bier *ohne Schaum", "1x Wasser"]` |
| no order exists while previewing | yes |
| **Zurück returns to the menu, cart intact (`11,00 €`)** | yes |
| **going back created no order** | yes |
| confirm → order created, printed, lands on the payment screen | yes |
| created order items | `[{quantity: 3, specialRequests: "ohne Schaum"}, {quantity: 1}]` |

That last row is the real check on the preview: the API stores `quantity: 3, specialRequests: "ohne Schaum"`, from which `formatOrderBon` computes `plainQty = 3 − 1 = 2` and emits `2x Bier`, then `1x Bier` / ` *ohne Schaum` — exactly the three lines the preview showed.

Also covered:

- **Empty cart on a direct URL load.** The cart is in-memory, so a hard navigation to `/check` drops it; the screen redirects to the menu instead of stranding the waiter on an empty confirmation.
- **Phone viewport (390×844)**, since that's the real target: no horizontal overflow, and the summary clears the fixed action row by 130px without scrolling.

One honest caveat: on a short, wide desktop viewport the summary card sits under the fixed action row until you scroll (gap is 151px once scrolled). That's the existing `.order-actions` pattern in this app — `.order-page` behaves the same — and it's clean on phones, so I left the pattern alone rather than reworking it here.

`tsc -b` + `vite build` clean; the existing e2e suite passes. `pnpm --filter waiter-web lint` reports the same 7 pre-existing errors as `main` — the new files add none. The throwaway spec is not committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
